### PR TITLE
Email security reports to distribution's security contacts

### DIFF
--- a/include/functions.php
+++ b/include/functions.php
@@ -1344,7 +1344,7 @@ function incoming_details_are_valid($in, $initial = 0, $logged_in = false)
  */
 function get_package_mail($package_name, $bug_id = false, $bug_type = 'Bug')
 {
-	global $dbh, $bugEmail, $docBugEmail, $secBugEmail;
+	global $dbh, $bugEmail, $docBugEmail, $secBugEmail, $security_distro_people;
 
 	$to = array();
 	$params = '-f noreply@php.net';


### PR DESCRIPTION
Only php.net's security team was receiving security reports, making them go unnoticed to the distribution contacts.
This patch assumes that people in the $security_developers array (other than those in  $security_distro_people) receive a copy from php.net's security address exploder.

To be reviewed by pajoye or somebody else.
