### PR TITLE
Enable logined user the ability to subscribe bugs

### DIFF
--- a/www/bug.php
+++ b/www/bug.php
@@ -69,7 +69,7 @@ if (isset($_POST['subscribe_to_bug']) || isset($_POST['unsubscribe_to_bug'])) {
 	}
 
 	if (empty($errors)) {
-		if ($logged_in && $auth_user->registered && !empty($auth_user->email)) {
+		if ($logged_in && !empty($auth_user->email)) {
 			$email = $auth_user->email;
 		} else {
 			$email = isset($_POST['in']['commentemail']) ? $_POST['in']['commentemail'] : '';
@@ -957,7 +957,11 @@ if ($edit == 1 || $edit == 2) { ?>
 
 <?php if ($logged_in) { ?>
 	<div class="explain">
-		<h1><a href="patch-add.php?bug_id=<?php echo $bug_id; ?>">Click Here to Submit a Patch</a></h1>
+		<h1>
+			<a href="patch-add.php?bug_id=<?php echo $bug_id; ?>">Click Here to Submit a Patch</a>
+			<input type="submit" name="subscribe_to_bug" value="Subscribe" />
+			<input type="submit" name="unsubscribe_to_bug" value="Unsubscribe" />
+		</h1>
 	</div>
 <?php } ?>
 


### PR DESCRIPTION
Before I got an account I could use the subscribe to keep myself been notified if anything on the bug,
but after I logged in I can't subscribe any bugs, but I'm not a php group member. so any update
can  not  reach me.

This patch shows the subscribe & unsubscribe button. 

even an php group member can subscribe it , since the email will send directly to him.
if he use filter, that might been helpful too.

BTW: 
The auth_user->registered didn't exists at all:
https://github.com/php/web-bugs/blob/master/include/functions.php#L133
so I remove it: https://github.com/reeze/web-bugs/pull/new/add-dev-subscrib#L0L72
