### PR TITLE
Prevent users from adding multiple votes on a single bug

### DIFF
--- a/www/bug.php
+++ b/www/bug.php
@@ -601,6 +601,9 @@ switch ($thanks)
 	case 9:
 		display_bug_success('You have successfully unsubscribed.');
 		break;
+	case 10:
+		display_bug_success('You have already voted on this bug.');
+	break;
 
 	default:
 		break;

--- a/www/bug.php
+++ b/www/bug.php
@@ -602,7 +602,7 @@ switch ($thanks)
 		display_bug_success('You have successfully unsubscribed.');
 		break;
 	case 10:
-		display_bug_success('You have already voted on this bug.');
+		display_bug_success('Your vote has been updated.');
 	break;
 
 	default:

--- a/www/vote.php
+++ b/www/vote.php
@@ -55,6 +55,16 @@ function get_real_ip ()
 $ip = ip2long(get_real_ip());
 // TODO: check if ip address has been banned. hopefully this will never need to be implemented.
 
+// Check whether the user has already voted on this bug.
+$bug_check = $dbh->prepare("SELECT bug, ip FROM bugdb_votes WHERE bug = ? AND ip = ? LIMIT 1")
+	->execute(array($id, $ip))
+	->fetchRow();
+
+if (!empty($bug_check)) {
+	// Let the user know they have already voted.
+	redirect("bug.php?id=$id&thanks=10");
+}
+
 // add the vote
 $dbh->prepare("
 	INSERT INTO bugdb_votes (bug,ip,score,reproduced,tried,sameos,samever)


### PR DESCRIPTION
Fixes [#51535](https://bugs.php.net/bug.php?id=51535) by implementing a single bug ID and IP check prior to inserting a users vote.