### PR TITLE
Bug #68801 	Edit button shall not show up if the logged in user is not the reporter

### DIFF
--- a/www/bug.php
+++ b/www/bug.php
@@ -679,12 +679,13 @@ if (!$show_bug_info) {
 
 <?php
 }
+
 if ($bug_id !== 'PREVIEW') {
 	echo '<div class="controls">', "\n",
 		control(0, 'View'),
 		($bug['private'] == 'N' ? control(3, 'Add Comment') : ''),
 		control(1, 'Developer'),
-		control(2, 'Edit'),
+		(!$email || $bug['email'] == $email? control(2, 'Edit') : ''),
 		'</div>', "\n";
 ?>
 <div class="clear"></div>


### PR DESCRIPTION
Hide the Edit button, if the Logged in user is not the reporter, because if the logged in user is not the reporter he wont be able to use this tab anyway.