### PR TITLE
Adds possibility to search for commenter-email

### DIFF
--- a/include/query.php
+++ b/include/query.php
@@ -68,7 +68,7 @@ if (isset($_GET['cmd']) && $_GET['cmd'] == 'display')
 	}
 
 	if ($commented_by != '') {
-		$query .= 'LEFT JOIN bugdb_comments c ON bugdb.id = c.bug';
+		$query .= ' LEFT JOIN bugdb_comments c ON bugdb.id = c.bug';
 	}
 	
 	$where_clause = ' WHERE 1 = 1 ';

--- a/include/query.php
+++ b/include/query.php
@@ -50,6 +50,7 @@ $assign = !empty($_GET['assign']) ? $_GET['assign'] : '';
 $author_email = !empty($_GET['author_email']) ? spam_protect($_GET['author_email'], 'reverse') : '';
 $package_name = (isset($_GET['package_name']) && is_array($_GET['package_name'])) ? $_GET['package_name'] : array();
 $package_nname = (isset($_GET['package_nname']) && is_array($_GET['package_nname'])) ? $_GET['package_nname'] : array();
+$commented_by = !empty($_GET['commented_by']) ? spam_protect($_GET['commented_by'], 'reverse') : '';
 
 if (isset($_GET['cmd']) && $_GET['cmd'] == 'display')
 {
@@ -64,7 +65,11 @@ if (isset($_GET['cmd']) && $_GET['cmd'] == 'display')
 	
 	if (in_array($order_by, array('votes_count', 'avg_score'))) {
 		$query .= 'LEFT JOIN bugdb_votes v ON bugdb.id = v.bug';
-	}		
+	}
+
+	if ($commented_by != '') {
+		$query .= 'LEFT JOIN bugdb_comments c ON bugdb.id = c.bug';
+	}
 	
 	$where_clause = ' WHERE 1 = 1 ';
 	
@@ -195,6 +200,9 @@ if (isset($_GET['cmd']) && $_GET['cmd'] == 'display')
 
 	if ($author_email != '') {
 		$where_clause .= ' AND bugdb.email = ' . $dbh->quote($author_email);
+	}
+	if ($commented_by != '') {
+		$where_clause .= ' AND c.email = ' . $dbh->quote($commented_by);
 	}
 
 	$where_clause .= ' AND (1=1';

--- a/www/search.php
+++ b/www/search.php
@@ -77,7 +77,8 @@ if (isset($_GET['cmd']) && $_GET['cmd'] == 'display')
 			'cve_id_not'  => $cve_id_not,
 			'patch'       => urlencode($patch),
 			'pull'        => urlencode($pull),
-			'assign'      => urlencode($assign)
+			'assign'      => urlencode($assign),
+			'commented_by' => urlencode($commented_by),
 		];
 
 		if ($is_security_developer) {
@@ -333,6 +334,11 @@ display_bug_error($warnings, 'warnings', 'WARNING:');
   <th>Pull Request</th>
   <td style="white-space: nowrap">Return only bugs with a <b>pull request</b></td>
   <td><input type="checkbox" name="pull" value="Y" <?php echo $pull == 'Y' ? " checked" : "" ?>></td>
+</tr>
+<tr>
+	<th>Commented by</th>
+	<td style="white-space: nowrap">Return bugs that have been <strong>commented by</strong></td>
+	<td><input type="email" name="commented_by" placeholder="me@example.com" value="<?php echo htmlspecialchars($commented_by, ENT_COMPAT, 'UTF-8'); ?>"></td>
 </tr>
 <?php
 	if ($is_security_developer) {


### PR DESCRIPTION
This PR enables us to search for bugs that have been commented using
a certain email-address.

It addresses [#69576](https://bugs.php.net/bug.php?id=69576)
