### PR TITLE
Clearer error message when rejecting comment as potential SPAM

### DIFF
--- a/www/bug.php
+++ b/www/bug.php
@@ -7,6 +7,8 @@ require_once '../include/prepend.php';
 // Start session 
 session_start();
 
+define('SPAM_REJECT_MESSAGE', 'Your comment looks like SPAM by its content.');
+
 // Handle preview
 if (isset($_REQUEST['id']) && $_REQUEST['id'] == 'preview') {
 	$bug_id = 'PREVIEW';
@@ -208,7 +210,7 @@ if (isset($_POST['ncomment']) && !isset($_POST['preview']) && $edit == 3) {
 
 	// primitive spam detection
 	if (is_spam($ncomment)) {
-		$errors[] = "Please do not SPAM our bug system.";
+		$errors[] = SPAM_REJECT_MESSAGE;
 	}
 
 	if (!$errors) {
@@ -242,7 +244,7 @@ if (isset($_POST['ncomment']) && !isset($_POST['preview']) && $edit == 3) {
 
 	// primitive spam detection
 	if (is_spam($ncomment)) {
-		$errors[] = "Please do not SPAM our bug system.";
+		$errors[] = SPAM_REJECT_MESSAGE;
 	}
 	
 	$from = $_POST['in']['commentemail'];
@@ -292,7 +294,7 @@ if (isset($_POST['ncomment']) && !isset($_POST['preview']) && $edit == 3) {
 
 	// primitive spam detection
 	if ($ncomment && is_spam($ncomment)) {
-		$errors[] = "Please do not SPAM our bug system.";
+		$errors[] = SPAM_REJECT_MESSAGE;
 	}
 
 	if (!empty($_POST['in']['email']) &&
@@ -359,7 +361,7 @@ if (isset($_POST['ncomment']) && !isset($_POST['preview']) && $edit == 3) {
 
 	// primitive spam detection
 	if (is_spam($ncomment)) {
-		$errors[] = "Please do not SPAM our bug system.";
+		$errors[] = SPAM_REJECT_MESSAGE;
 	}
 
 } elseif (isset($_POST['in']) && is_array($_POST['in']) && !isset($_POST['preview']) && $edit == 1) {
@@ -385,7 +387,7 @@ if (isset($_POST['ncomment']) && !isset($_POST['preview']) && $edit == 3) {
 
 	// primitive spam detection
 	if ($ncomment && is_spam($ncomment)) {
-		$errors[] = "Please do not SPAM our bug system.";
+		$errors[] = SPAM_REJECT_MESSAGE;
 	}
 	
 	// Just trusted dev can set CVE-ID


### PR DESCRIPTION
Don't make users waste their time trying to figure out why their comment is being rejected.
The overall quality of this bug tracker (not to mention the attitude of bug triagers) is already disrespectful enough to people who are trying to help by reporting bugs. Let's alliviate it a little bit at least when it's trivial.
