### PR TITLE
[WIP] Migrate to PDO using compatibility layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,6 @@ Requirements
 - PHP 5.4+
 - `ext/openssl` (for https:// fopen wrapper)
 - PEAR packages:
-	- MDB2
-	- MDB2#mysql
-	- MDB2#mysqli
-	- DB_DataObject
 	- Text_CAPTCHA_Numeral
 	- Text_Diff
 	- HTTP_Upload
@@ -19,7 +15,7 @@ Installation
 ============
 1. Copy `local_config.php.sample` to `local_config.php` and modify accordingly
 2. Install all required packages:
-`pear install MDB2 MDB2#mysql MDB2#mysqli DB_DataObject Text_CAPTCHA_Numeral Text_Diff HTTP_Upload`
+`pear install Text_CAPTCHA_Numeral Text_Diff HTTP_Upload`
 3. Import SQL schema from `sql/bugs.sql`
 
 TODO

--- a/include/classes/bug_pdo.php
+++ b/include/classes/bug_pdo.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * Thin compatibility layer between MDB2 and PDO for bugs.php.net.
+ * 
+ * Please mind that it's not meant to implement full feature set, 
+ * but only this used by our existing codebase. New code interacting
+ * with the database should be written using standard PDO's approach.
+ *
+ * @author Maciej Sobaczewski <sobak@php.net>
+ */
+
+// Define missing constants
+define('MDB2_FETCHMODE_ASSOC', null);
+define('MDB2_FETCHMODE_ORDERED', null);
+define('MDB2_PREPARE_MANIP', null);
+
+class Bug_PDO extends PDO
+{
+    /**
+     * When creating new PDO object, automagically switch PDOStatement with
+     * own extended implementation.
+     */
+    public function __construct($dsn, $username = '', $password = '', array $options = [])
+    {
+        parent::__construct($dsn, $username, $password, $options);
+
+        $this->setAttribute(PDO::ATTR_STATEMENT_CLASS, ['Bug_PDOStatement']);
+    }
+
+    /**
+     * MDB2::espace() doesn't put apostrophes around the text and PDO does so we
+     * need to strip outermost characters.
+     */
+    public function escape($text, $escape_wildcards = false)
+    {
+        return substr($this->quote($text), 1, -1);
+    }
+
+    public function queryAll($query, $types = null, $fetchmode = null, $rekey = false, $force_array = false, $group = false)
+    {
+        return $this->query($query)->fetchAll();
+    }
+}
+
+class Bug_PDOStatement extends PDOStatement
+{
+    /**
+     * MDB2 allows for chaining execute() method like so:
+     *   $db->query('SELECT a FROM b WHERE c = ?')->execute('foo')->fetch();
+     * PDOStatement::execute(), on the other hand, returns boolean. Change it
+     * to return $this and thus allow futher method chaining.
+     */
+    public function execute(array $input_parameters = [])
+    {
+        parent::execute($input_parameters);
+
+        return $this;
+    }
+
+    public function fetchAll($fetchode = null, $rekey = false, $force_array = false, $group = false)
+    {
+        return parent::fetchAll();
+    }
+
+    public function fetchCol($colnum)
+    {
+        return parent::fetchColumn($colnum);
+    }
+
+    public function fetchOne($colnum = 0, $rownum = null)
+    {
+        return $this->fetch(PDO::FETCH_NUM)[0];
+    }
+
+    public function fetchRow($mode)
+    {
+        return $this->fetch();
+    }
+}

--- a/include/functions.php
+++ b/include/functions.php
@@ -796,13 +796,7 @@ function show_boolean_options($current)
  */
 function display_bug_error($in, $class = 'errors', $head = 'ERROR:')
 {
-	if (PEAR::isError($in)) {
-		if (DEVBOX == true) {
-			$in = array($in->getMessage() . '... ' . $in->getUserInfo());
-		} else {
-			$in = array($in->getMessage());
-		}
-	} elseif (!is_array($in)) {
+	if (!is_array($in)) {
 		$in = array($in);
 	} elseif (!count($in)) {
 		return false;
@@ -810,13 +804,6 @@ function display_bug_error($in, $class = 'errors', $head = 'ERROR:')
 
 	echo "<div class='{$class}'>{$head}<ul>";
 	foreach ($in as $msg) {
-		if (PEAR::isError($msg)) {
-			if (DEVBOX == true) {
-				$msg = $msg->getMessage() . '... ' . $msg->getUserInfo();
-			} else {
-				$msg = $msg->getMessage();
-			}
-		}
 		echo '<li>' , htmlspecialchars($msg) , "</li>\n";
 	}
 	echo "</ul></div>\n";
@@ -1356,10 +1343,6 @@ function get_package_mail($package_name, $bug_id = false, $bug_type = 'Bug')
 			WHERE name = ?
 		')->execute([$package_name]);
 
-		if (PEAR::isError($res)) {
-			throw new Exception('SQL Error in get_package_name(): ' . $res->getMessage());
-		}
-
 		list($list_email, $project) = $res->fetchRow();
 
 		if ($project == 'pecl') {
@@ -1568,7 +1551,7 @@ function get_resolve_reasons($project = false)
 
 	$resolves = $variations = array();
 	$res = $dbh->prepare("SELECT * FROM bugdb_resolves $where")->execute(array());
-	if (PEAR::isError($res)) {
+	if (!$res) {
 		throw new Exception("SQL Error in get_resolve_reasons");
 	}
 	while ($row = $res->fetchRow(MDB2_FETCHMODE_ASSOC)) {

--- a/include/prepend.php
+++ b/include/prepend.php
@@ -45,23 +45,20 @@ $docBugEmail = $site_data['doc_email'];
 $secBugEmail = $site_data['security_email'];
 $basedir = $site_data['basedir'];
 define('BUG_PATCHTRACKER_TMPDIR', $site_data['patch_tmp']);
-define('DATABASE_DSN', "{$site_data['db_extension']}://{$site_data['db_user']}:{$site_data['db_pass']}@{$site_data['db_host']}/{$site_data['db']}");
+define('DATABASE_DSN', "mysql:host={$site_data['db_host']};dbname={$site_data['db']};charset=utf8");
 
 /**
  * Obtain the functions and variables used throughout the bug system
  */
 require_once "{$ROOT_DIR}/include/functions.php";
+require 'classes/bug_pdo.php';
 
 // Database connection (required always?)
-include_once 'MDB2.php';
-
-PEAR::setErrorHandling(PEAR_ERROR_CALLBACK, 'handle_pear_errors');
-
-if (empty($dbh))
-{
-	$dbh = MDB2::factory(DATABASE_DSN);
-	$dbh->loadModule('Extended');
-}
+$dbh = new Bug_PDO(DATABASE_DSN, $site_data['db_user'], $site_data['db_pass'], [
+    PDO::ATTR_ERRMODE            => PDO::ERRMODE_EXCEPTION,
+    PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+    PDO::ATTR_EMULATE_PREPARES   => false,
+]);
 
 // Last Updated..
 $tmp = filectime($_SERVER['SCRIPT_FILENAME']);

--- a/include/query.php
+++ b/include/query.php
@@ -255,14 +255,13 @@ if (isset($_GET['cmd']) && $_GET['cmd'] == 'display')
 	if (stristr($query, ';')) {
 		$errors[] = 'BAD HACKER!! No database cracking for you today!';
 	} else {
-		$res = $dbh->prepare($query)->execute();
-		if (!PEAR::isError($res)) {
-			$rows = $res->numRows();
+		try {
+			$result = $dbh->prepare($query)->execute()->fetchAll();
+			$rows = count($result);
 			$total_rows = $dbh->prepare('SELECT FOUND_ROWS()')->execute()->fetchOne();
-		} else {
-			$error = MDB2::errorMessage($res);
-			$errors[] = $error;
-		}		
+		} catch (Exception $e) {
+			$errors[] = 'Invalid query: ' . $e->getMessage();
+		}
 		if (defined('MAX_BUGS_RETURN') && $total_rows > $rows) {
 			$warnings[] = 'The search was too general, only ' . MAX_BUGS_RETURN . ' bugs will be returned';
 		}

--- a/local_config.php.sample
+++ b/local_config.php.sample
@@ -12,7 +12,6 @@ $site_data = array (
 	'doc_email' => 'doc-bugs@lists.php.net',
 	'security_email' => 'security@php.net',
 	'db' => 'phpbugsdb',
-	'db_extension' => 'mysqli',
 	'db_user' => 'nobody',
 	'db_pass' => '',
 	'db_host' => 'localhost',

--- a/scripts/cron/email-assigned
+++ b/scripts/cron/email-assigned
@@ -16,17 +16,10 @@ $sql = "SELECT id, package_name, bug_type, sdesc, status, assign, UNIX_TIMESTAMP
 
 $res = $dbh->query($sql);
 
-if (PEAR::isError($res)) {
-	throw new Exception("SQL Error in email-assigned");
-}
-
 // Gather up the data
 while ($row = $res->fetchRow(MDB2_FETCHMODE_ASSOC)) {
 	$data[$row['assign']][] = $row;
 }
-
-$num_rows  = $res->numRows();
-$num_users = count($data);
 
 foreach ($data as $assigned => $binfos) {
 

--- a/templates/search-rdf.php
+++ b/templates/search-rdf.php
@@ -25,7 +25,7 @@ echo '	<items>
 
 $items = '';
 if ($total_rows > 0) {
-	foreach ($res->fetchAll(MDB2_FETCHMODE_ASSOC) as $row) {
+	foreach ($result as $row) {
 		$desc = "{$row['package_name']} ({$row['bug_type']})\nReported by ";
 		if (preg_match('/@php.net$/i', $row['email'])) {
 			$desc .= substr($row['email'], 0, strpos($row['email'], '@')) ."\n";

--- a/templates/search-rss2.php
+++ b/templates/search-rss2.php
@@ -9,7 +9,7 @@ echo '<?xml version="1.0"?>' . "\n";
   <description>Search Results</description>
 <?php
 if ($total_rows > 0) {
-	foreach ($res->fetchAll(MDB2_FETCHMODE_ASSOC) as $row) {
+	foreach ($result as $row) {
 		echo "  <item>\n";
 		echo '   <title>' . clean($row['sdesc']) . "</title>\n";
 		echo "   <link>{$site_method}://{$site_url}{$basedir}/{$row['id']}</link>\n";

--- a/www/report.php
+++ b/www/report.php
@@ -76,9 +76,9 @@ if (isset($_POST['in'])) {
 
 			$query = "SELECT * from bugdb $where_clause LIMIT 5";
 
-			$res = $dbh->prepare($query)->execute();
+			$possible_duplicates = $dbh->prepare($query)->execute()->fetchAll();
 
-			if ($res->numRows() == 0) {
+			if (count($possible_duplicates) == 0) {
 				$ok_to_submit_report = true;
 			} else {
 				response_header("Report - Confirm");
@@ -107,7 +107,7 @@ if (isset($_POST['in'])) {
 						</tr>
 <?php
 
-				foreach ($res->fetchAll(MDB2_FETCHMODE_ASSOC) as $row) {
+				foreach ($possible_duplicates as $row) {
 					$resolution = $dbh->prepare("
 						SELECT comment 
 						FROM bugdb_comments
@@ -215,11 +215,7 @@ OUTPUT;
 					$_SERVER['REMOTE_ADDR']
 				)
 			);
-			if (PEAR::isError($res)) {
-				echo "<pre>";
-				var_dump($_POST['in'], $fdesc, $package_name);
-				die($res->getMessage());
-			}
+
 			$cid = $dbh->lastInsertId();
 
 			$redirectToPatchAdd = false;

--- a/www/rss/search.php
+++ b/www/rss/search.php
@@ -28,14 +28,6 @@ if ($format === 'rss2') {
 require_once '../../include/prepend.php';
 require "{$ROOT_DIR}/include/query.php";
 
-if (!isset($res)) {
-	die('Invalid query');
-} else {
-	$res  = $dbh->prepare($query)->execute();
-	$rows = $res->numRows();
-	$total_rows = $dbh->prepare('SELECT FOUND_ROWS()')->execute()->fetchOne();
-}
-
 if ($format === 'rss2') {
 	require "{$ROOT_DIR}/templates/search-rss2.php";
 } else {

--- a/www/search.php
+++ b/www/search.php
@@ -34,7 +34,10 @@ require "{$ROOT_DIR}/include/query.php";
 
 if (isset($_GET['cmd']) && $_GET['cmd'] == 'display')
 {
-	if (!isset($res)) {
+	// FIXME: this if doesn't make sense, check is already performed in
+	// query.php - whole condition can be removed, reducing level of
+	// nesting by one.
+	if (!isset($result)) {
 		$errors[] = 'Invalid query';
 	} else {
 		// For count only, simply print the count and exit
@@ -144,7 +147,7 @@ if (isset($_GET['cmd']) && $_GET['cmd'] == 'display')
  </tr>
 <?php
 
-			while ($row = $res->fetchRow(MDB2_FETCHMODE_ASSOC)) {
+			foreach ($result as $row) {
 				$status_class = $row['private'] == 'Y' ? 'Sec' : $tla[$row['status']];
 
 				echo ' <tr valign="top" class="' , $status_class, '">' , "\n";


### PR DESCRIPTION
I tried to start a migration several times in the past and gave up each time - this codebase is too critical and  messy to do this reliably. This time I changed my approach - I decided to write thin compatibility layer between MDB2 and PDO APIs. Most of the existing code should remain untouched with only exceptions being:

- calls to `numRows()` which PDO has no counterpart of
- errors handling: application-wide exception handler will need to be added

This is obviously still work in progress but I'd love to hear any opinions on general idea of migrating to PDO, suggested approach and its implementation so far.