### PR TITLE
Improve privacy and spam protection

### DIFF
--- a/include/functions.php
+++ b/include/functions.php
@@ -328,6 +328,7 @@ function spam_protect($txt, $format = 'html')
 	if (preg_match('/^(.+)@php\.net$/i', $txt)) {
 		return $txt;
 	}
+	$email = substr($txt, 0, strrpos($txt, '@'));
 	if ($format == 'html') {
 		$translate = array(
 			'@' => ' &#x61;&#116; ',


### PR DESCRIPTION
The bug tracker displays the email addresses of bug reporters and
commenters.  This does not appear to be necessary (unless we would
encourage "off-list" discussions), and may violate the users privacy.
Also it may encourage users to enter an invalid or plain wrong email
address, which would prevent that they actually receive notes regarding
comments, which may potentially a request for feedback.

Furthermore, albeit the bug tracker currently uses the most
sophisticated email obfuscation, it might still be possible to crack
this spam protection, considering still increasing computational power
and ongoing improvements in AI. ;)

Therefore, we do not show the full email address anymore, but rather
omit the domain name, which appears to be sufficient be able to follow
the conversation and to address a certain poster, if necessary.
php.net addresses are kept unchanged as hithertho.