### PR TITLE
removed unused parameters

### DIFF
--- a/include/functions.php
+++ b/include/functions.php
@@ -687,11 +687,10 @@ function show_reason_types($current = '', $expanded = 0)
  * Prints PHP version number <option>'s for use in a <select> list
  *
  * @param string $current	the bug's current version number
- * @param string $default	a version number that should be the default
  *
  * @return void
  */
-function show_version_options($current, $default = '')
+function show_version_options($current)
 {
 	global $ROOT_DIR, $versions;
 

--- a/www/bug.php
+++ b/www/bug.php
@@ -1246,7 +1246,7 @@ function delete_comment($bug_id, $com_id)
 {
 	global $dbh;
 	
-	$res = $dbh->prepare("DELETE FROM bugdb_comments WHERE bug='{$bug_id}' AND id='{$com_id}'")->execute();
+	$dbh->prepare("DELETE FROM bugdb_comments WHERE bug='{$bug_id}' AND id='{$com_id}'")->execute();
 }
 
 function control($num, $desc)


### PR DESCRIPTION
Remove unused parameter `$default` from `show_version_options` function which called in 
https://github.com/php/web-bugs/blob/master/www/report.php#L421

and remove unused parameter `$res` from `delete_comment` function