### PR TITLE
Remove ascending ordering of GitHub PRs

### DIFF
--- a/templates/addghpull.php
+++ b/templates/addghpull.php
@@ -148,9 +148,6 @@ $(document).ready(function() {
 
     var url = baseurl + 'repos/' + org + '/' + repo + '/pulls?per_page=' + MAX_PER_PAGE;
     recursiveFetch(url, [], function(items) {
-      items.sort(function (a, b) {
-        return a.number - b.number;
-      });
       items.map(function(item) {
         $("#pull_id_field").append("<option value=" + (item.number + 0) + ">" + item.number + " - " + item.title + "</option>");
       });


### PR DESCRIPTION
When we wanna attach a PR to a bug, we are usually looking for the most recent ones :smile: 