### PR TITLE
Add line-height to .note CSS class

### DIFF
--- a/www/css/style.css
+++ b/www/css/style.css
@@ -535,6 +535,7 @@ td.content table {
 	margin-left: 10px;
 	white-space:pre-wrap;
 	font-size: 13px;
+	line-height: 1.4;
 }
 .lusersearch .note {
 	width:100%;


### PR DESCRIPTION
Hello, the `line-height` of `1.4` makes the text more readable.

## Before:
![bugs_1](https://user-images.githubusercontent.com/1614009/40695433-848d72ee-63c1-11e8-92f2-fc3270760778.png)


## After:
![bugs_2](https://user-images.githubusercontent.com/1614009/40695447-9053be4e-63c1-11e8-8d82-2656077adc88.png)

Thanks for checking this out or considering merging it.