### PR TITLE
Remove unused Git ident attribute

### DIFF
--- a/www/css/style.css
+++ b/www/css/style.css
@@ -1,5 +1,3 @@
-/* $Id$ */
-
 body {
 	margin: 0px;
 	padding: 0px;


### PR DESCRIPTION
$Id$ keywords were used in Subversion where they can be substituted with filename,
last revision number change, last changed date, and last user who changed it.

In Git this functionality is different and can be done with Git ident attributes.
These need to be defined manually for each file in the .gitattributes file and
are afterwards replaced with blob object name which is based only on particular
file contents.

This patch simplifes handling of $Id$ keywords by removing them since they are
not used anymore.

Thanks for considering merging this or checking this out.