### PR TITLE
Apply line-height CSS style to all pre tags

### DIFF
--- a/www/css/style.css
+++ b/www/css/style.css
@@ -429,6 +429,10 @@ code, pre, tt {
 	font-size: 13px;
 }
 
+pre {
+	line-height: 1.4;
+}
+
 h1 {
 	font-size: 140%;
 	font-weight: bold;
@@ -535,7 +539,6 @@ td.content table {
 	margin-left: 10px;
 	white-space:pre-wrap;
 	font-size: 13px;
-	line-height: 1.4;
 }
 .lusersearch .note {
 	width:100%;


### PR DESCRIPTION
This improves readability when <pre> tags are used. For example, also when viewing patches, and [similar pages](https://bugs.php.net/bugs-generating-backtrace.php)...

Before:
![prev_1](https://user-images.githubusercontent.com/1614009/43700303-6ed44952-9952-11e8-8ea3-cd47904e56e7.png)

After:
![prev_2](https://user-images.githubusercontent.com/1614009/43700325-7a1c5d36-9952-11e8-94f6-da3e866fba1b.png)
