### PR TITLE
Remove unused CSS items

### DIFF
--- a/www/css/style.css
+++ b/www/css/style.css
@@ -421,10 +421,7 @@ hr {
 	color: #66cc66;
 }
 
-.compact {
-}
-
-code, pre, tt {
+code, pre {
 	font-family: Consolas, Inconsolata, "Liberation Mono", monospace;
 	font-size: 13px;
 }


### PR DESCRIPTION
This patch removes 2 occurrences of unused CSS items. The `tt` tag is even obsolete...

Thank you.