### PR TITLE
Package name categories are optgroups

### DIFF
--- a/include/functions.php
+++ b/include/functions.php
@@ -235,7 +235,8 @@ function get_pseudo_packages($project, $return_disabled = true)
 	foreach ($tree as $data)
 	{
 		if (isset($data['children'])) {
-			$pseudo_pkgs[$data['name']] = array($data['long_name'], $data['disabled']);
+			$pseudo_pkgs[$data['name']] = array($data['long_name'], $data['disabled'], array());
+			$children = &$pseudo_pkgs[$data['name']][2];
 			$long_names = array();
 			foreach ($data['children'] as $k => $v) {
 				$long_names[$k] = strtolower($v['long_name']);
@@ -243,11 +244,12 @@ function get_pseudo_packages($project, $return_disabled = true)
 			array_multisort($long_names, SORT_ASC, SORT_STRING, $data['children']);
 			foreach ($data['children'] as $child)
 			{
-				$pseudo_pkgs[$child['name']] = array("&nbsp;&nbsp;&nbsp;&nbsp;{$child['long_name']}", $child['disabled']);
+				$pseudo_pkgs[$child['name']] = array("{$child['long_name']}", $child['disabled'], null);
+				$children[] = $child['name'];
 			}
 
 		} elseif (!isset($pseudo_pkgs[$data['name']])) {
-			$pseudo_pkgs[$data['name']] = array($data['long_name'], $data['disabled']);
+			$pseudo_pkgs[$data['name']] = array($data['long_name'], $data['disabled'], null);
 		}
 	}
 

--- a/include/functions.php
+++ b/include/functions.php
@@ -728,10 +728,16 @@ function show_version_options($current)
 function show_package_options($current, $show_any, $default = '')
 {
 	global $pseudo_pkgs;
-	static $bug_items;
+	$disabled_style = ' style="background-color:#eee;"';
+	static $bug_groups;
 
-	if (!isset($bug_items)) {
-		$bug_items = $pseudo_pkgs;
+	if (!isset($bug_groups)) {
+		$bug_groups = array_filter(
+			$pseudo_pkgs,
+			function ($value) {
+				return is_array($value[2]);
+			}
+		);
 	}
 
 	if (!$current && (!$default || $default == 'none') && !$show_any) {
@@ -742,19 +748,28 @@ function show_package_options($current, $show_any, $default = '')
 		$current = $default;
 	}
 
-	if (!is_array($bug_items)) {
+	if (!is_array($bug_groups)) {
 		return;
 	}
 
-	foreach ($bug_items as $key => $value) {
-		if ($show_any == 1 || $key != 'Any') {
-			echo "<option value=\"$key\"";
-			if ((is_array($current) && in_array($key, $current)) || ($key == $current)) {
-				echo ' selected="selected"';
+
+	foreach ($bug_groups as $key => $bug_group) {
+		echo "<optgroup label=\"${bug_group[0]}\"" .
+			(($bug_group[1]) ? $disabled_style : ''), "\n>";
+
+		array_unshift($bug_group[2], $key);
+		foreach ($bug_group[2] as $name) {
+			$child = $pseudo_pkgs[$name];
+			if ($show_any == 1 || $key != 'Any') {
+				echo "<option value=\"$name\"";
+				if ((is_array($current) && in_array($key, $current)) || ($key == $current)) {
+					echo ' selected="selected"';
+				}
+				// Show disabled categories with different background color in listing
+				echo (($child[1]) ? $disabled_style : ''), ">{$child[0]}</option>\n";
 			}
-			// Show disabled categories with different background color in listing
-			echo (($value[1]) ? ' style="background-color:#eee;"' : ''), ">{$value[0]}</option>\n";
 		}
+		echo "</optgroup>\n";
 	}
 }
 


### PR DESCRIPTION
Previously, packages within categories were indented with 4 `&nbsp;`s to indicate that they were part of a category. We instead now distinguish categories with `<optgroup>` tag, which will help any user who uses their keyboard for package name autocompletion.

This was accomplished by adding a third element to the `$pseudo_pkgs` global. Fortunately, other than includes/functions.php, `$pseudo_pkgs` is only used for its array keys (www/lstats.php:51, include/query.php:210). In the other scripts where `$psudo_pkgs` is bound by `get_pseudo_packages()`, it does not seem to be used (www/patch-display.php:50, www/report.php:14, www/bug.php:178, www/stats.php:38, www/stats.php:38).