### PR TITLE
Bug #76885 - Fix login after logout

### DIFF
--- a/www/login.php
+++ b/www/login.php
@@ -18,7 +18,7 @@ if (isset($_POST['user'])) {
   if ($logged_in === 'developer') {
 	if (!empty($_POST['referer']) &&
 		preg_match("/^{$site_method}:\/\/". preg_quote($site_url) .'/i', $referer) &&
-		parse_url($referer)['path'] != '/logout.php') {
+		parse_url($referer, PHP_URL_PATH) != '/logout.php') {
 		redirect($referer);
 	}
     redirect('index.php');


### PR DESCRIPTION
After dd867c4277, logging in immediately after logging out will send you to `index.php` instead of `logout.php`.