### PR TITLE
Bug #76273: When JavaScript is enabled, choose the package affected by choosing the category first

### DIFF
--- a/www/js/package-affected.js
+++ b/www/js/package-affected.js
@@ -1,0 +1,1 @@
+'use strict';

--- a/www/js/package-affected.js
+++ b/www/js/package-affected.js
@@ -7,7 +7,10 @@ window.addEventListener(
 			.querySelectorAll('select[name="in[package_name]"]')
 			.forEach(
 				function (select) {
-					var packageGroup = document.createElement('select');
+					var packageGroup = document.createElement('select'),
+						initialValue = select.value,
+						initialGroup = select.querySelector(':scope option[value="' + initialValue + '"]').parentNode;
+
 					packageGroup.name = 'in[package_group]';
 
 					select
@@ -20,8 +23,69 @@ window.addEventListener(
 								packageOption.textContent = groupName;
 								packageOption.value = groupName;
 								packageGroup.appendChild(packageOption);
+
+								optgroup
+									.querySelectorAll(':scope option')
+									.forEach(
+										function (option) {
+											option.setAttribute('bug-group', groupName);
+										}
+									);
 							}
 						);
+
+					var instructions = select.querySelector(':scope option[value="none"]');
+					if (instructions instanceof HTMLElement) {
+						instructions.textContent = 'Select a category';
+					}
+
+					select
+						.querySelectorAll(':scope optgroup')
+						.forEach(
+							function (optgroup) {
+								optgroup.style.display = 'none';
+							}
+						);
+
+					function updateGroup() {
+						select.disabled = false;
+
+						if (instructions instanceof HTMLElement) {
+							instructions.style.display = 'none';
+						}
+
+						var previousOptions = select.querySelectorAll(':scope > option:not([value=none])'),
+							nextLabel = packageGroup.value,
+							nextGroup = select.querySelector(':scope optgroup[label="' + nextLabel + '"]');
+
+						if (previousOptions.length !== 0) {
+							var previousLabel = previousOptions[0].getAttribute('bug-group'),
+								previousGroup = select.querySelector(':scope optgroup[label="' + previousLabel + '"]');
+
+							moveOptions(select, previousGroup);
+						}
+
+						moveOptions(nextGroup, select);
+					}
+
+					function moveOptions(from, to) {
+						from.querySelectorAll(':scope > option')
+							.forEach(
+								function (option) {
+									to.appendChild(option);
+								}
+							);
+					}
+
+					packageGroup.addEventListener('change', updateGroup);
+
+					if (initialGroup instanceof HTMLOptGroupElement) {
+						packageGroup.value = initialGroup.label;
+						moveOptions(initialGroup, select);
+					} else {
+						select.disabled = true;
+						select.value = null;
+					}
 
 					select
 						.parentNode

--- a/www/js/package-affected.js
+++ b/www/js/package-affected.js
@@ -87,6 +87,14 @@ window.addEventListener(
 						select.value = null;
 					}
 
+					packageGroup.style.marginRight = '.5em';
+					[select, packageGroup].forEach(
+						function (element) {
+							element.size = 5;
+							element.style.width = '22em';
+						}
+					);
+
 					select
 						.parentNode
 						.insertBefore(packageGroup, select);

--- a/www/js/package-affected.js
+++ b/www/js/package-affected.js
@@ -1,1 +1,32 @@
 'use strict';
+
+window.addEventListener(
+	'load',
+	function () {
+		document
+			.querySelectorAll('select[name="in[package_name]"]')
+			.forEach(
+				function (select) {
+					var packageGroup = document.createElement('select');
+					packageGroup.name = 'in[package_group]';
+
+					select
+						.querySelectorAll(':scope optgroup')
+						.forEach(
+							function (optgroup) {
+								var packageOption = document.createElement('option'),
+									groupName = optgroup.label;
+
+								packageOption.textContent = groupName;
+								packageOption.value = groupName;
+								packageGroup.appendChild(packageOption);
+							}
+						);
+
+					select
+						.parentNode
+						.insertBefore(packageGroup, select);
+				}
+			);
+	}
+);

--- a/www/report.php
+++ b/www/report.php
@@ -27,6 +27,10 @@ if (!$logged_in) {
 	$numeralCaptcha = new Text_CAPTCHA_Numeral();
 }
 
+$packageAffectedScript = <<<SCRIPT
+	<script type="text/javascript" src="$site_method://$site_url$basedir/js/package-affected.js"></script>
+SCRIPT;
+
 // Handle input
 if (isset($_POST['in'])) {
 
@@ -81,7 +85,7 @@ if (isset($_POST['in'])) {
 			if (count($possible_duplicates) == 0) {
 				$ok_to_submit_report = true;
 			} else {
-				response_header("Report - Confirm");
+				response_header("Report - Confirm", $packageAffectedScript);
 				if (count($_FILES)) {
 					echo '<h1>WARNING: YOU MUST RE-UPLOAD YOUR PATCH, OR IT WILL BE IGNORED</h1>';
 				}
@@ -150,7 +154,7 @@ OUTPUT;
 		
 		if (isset($_POST['edit_after_preview'])) {
 			$ok_to_submit_report = false;
-			response_header("Report - New");
+			response_header("Report - New", $packageAffectedScript);
 		}
 
 		if ($ok_to_submit_report) {
@@ -317,14 +321,14 @@ REPORT;
 		}
 	} else {
 		// had errors...
-		response_header('Report - Problems');
+		response_header('Report - Problems', $packageAffectedScript);
 	}
 } // end of if input
 
 $package = !empty($_REQUEST['package']) ? $_REQUEST['package'] : (!empty($package_name) ? $package_name : (isset($_POST['in']) && $_POST['in'] && isset($_POST['in']['package_name']) ? $_POST['in']['package_name'] : ''));
 
 if (!is_string($package)) {
-	response_header('Report - Problems');
+	response_header('Report - Problems', $packageAffectedScript);
 	$errors[] = 'Invalid package name passed. Please fix it and try again.';
 	display_bug_error($errors);
 	response_footer();
@@ -346,7 +350,9 @@ if (!isset($_POST['in'])) {
 			 'php_os' => '',
 			 'passwd' => '',
 	);
-	response_header('Report - New');
+
+
+	response_header('Report - New', $packageAffectedScript);
 ?>
 
 	<p>


### PR DESCRIPTION
[As suggested](https://bugs.php.net/bug.php?id=76273) by Bert, The "packages affected" dropdown has been split into 2 menus: One to choose the category and one to find the exact package.

The structure of POST requests does not change beyond additionally receiving `in[package_group]`. As this is a frontend-only solution, the existing form is functional and unchanged when JavaScript is disabled.

Supported in Chrome 51+, Firefox 50+, Opera 38+, and Safari 10+, limited by [`NodeList.prototype.forEach`](https://developer.mozilla.org/en-US/docs/Web/API/NodeList/forEach#Browser_Compatibility) and [`:scope`](https://developer.mozilla.org/en-US/docs/Web/CSS/:scope#Browser_compatibility)