### PR TITLE
Change visitor_ip MySQL field type to varbinary(16)

### DIFF
--- a/sql/bugs.sql
+++ b/sql/bugs.sql
@@ -21,7 +21,7 @@ CREATE TABLE bugdb (
   block_user_comment char(1) default 'N',
   cve_id varchar(15) default NULL,
   private char(1) default 'N',
-  visitor_ip int(10) unsigned NOT NULL,
+  visitor_ip varbinary(16) NOT NULL,
   PRIMARY KEY (id),
   KEY php_version (php_version(1)),
   KEY status (status),
@@ -37,7 +37,7 @@ CREATE TABLE bugdb_comments (
   ts datetime NOT NULL default CURRENT_TIMESTAMP,
   comment text NOT NULL,
   comment_type varchar(10) default 'comment',
-  visitor_ip int(8) UNSIGNED NOT NULL,
+  visitor_ip varbinary(16) NOT NULL,
   PRIMARY KEY  (id),
   KEY bug (bug,id,ts),
   FULLTEXT KEY comment (comment)


### PR DESCRIPTION
This now enables local installation more easily without manually adjusting the field. The new varbinary field has been recently updated in the code for reporting bugs and adding comments.