### PR TITLE
Update http to https

### DIFF
--- a/include/functions.php
+++ b/include/functions.php
@@ -1741,9 +1741,9 @@ function response_header($title, $extraHeaders = '')
 		</td>
 
 		<td class="head-menu">
-			<a href="http://www.php.net/">php.net</a>&nbsp;|&nbsp;
-			<a href="http://www.php.net/support.php">support</a>&nbsp;|&nbsp;
-			<a href="http://www.php.net/docs.php">documentation</a>&nbsp;|&nbsp;
+			<a href="https://php.net/">php.net</a>&nbsp;|&nbsp;
+			<a href="https://php.net/support.php">support</a>&nbsp;|&nbsp;
+			<a href="https://php.net/docs.php">documentation</a>&nbsp;|&nbsp;
 			<a href="report.php">report a bug</a>&nbsp;|&nbsp;
 			<a href="search.php">advanced search</a>&nbsp;|&nbsp;
 			<a href="search-howto.php">search howto</a>&nbsp;|&nbsp;
@@ -1805,8 +1805,8 @@ function response_footer($extra_html = '')
 	<tr>
 		<td class="foot-copy">
 			<small>
-				<a href="http://www.php.net/"><img src="images/logo-small.gif" align="left" valign="middle" hspace="3" alt="PHP"></a>
-				<a href="http://www.php.net/copyright.php">Copyright &copy; 2001-<?php echo date('Y'); ?> The PHP Group</a><br>
+				<a href="https://php.net/"><img src="images/logo-small.gif" align="left" valign="middle" hspace="3" alt="PHP"></a>
+				<a href="https://php.net/copyright.php">Copyright &copy; 2001-<?php echo date('Y'); ?> The PHP Group</a><br>
 				All rights reserved.
 			</small>
 		</td>

--- a/include/php_versions.php
+++ b/include/php_versions.php
@@ -1,14 +1,14 @@
 <?php
 
 	/*
-	The RC and dev versions are pulled from the http://qa.php.net/api.php
+	The RC and dev versions are pulled from the https://qa.php.net/api.php
 	if you want to add a new version, add it there at include/release-qa.php
 	the result is cached for an hour in /tmp/<systemd>/tmp/versions.php
 	the versions are weighted by the following:
 	- major+minor version desc (7>5.4>5.3>master)
 	- between a minor version we order by the micro if available: first the qa releases: alpha/beta/rc, then the stable, then the Git versions(snaps, Git)
 
-	Stable releases are pulled from http://php.net/releases/active.php
+	Stable releases are pulled from https://php.net/releases/active.php
 	*/
 
 	// Custom versions appended to the list
@@ -29,7 +29,7 @@
 	$versions = array_merge($versions, $custom_versions);
 
 	function buildVersions() {
-		$dev_versions = json_decode(file_get_contents('http://qa.php.net/api.php?type=qa-releases&format=json&only=dev_versions'));
+		$dev_versions = json_decode(file_get_contents('https://qa.php.net/api.php?type=qa-releases&format=json&only=dev_versions'));
 
 		$versions = array();
 
@@ -55,7 +55,7 @@
 			}
 		}
 
-		$stable_releases = json_decode(file_get_contents('http://us3.php.net/releases/active.php'), true);
+		$stable_releases = json_decode(file_get_contents('https://php.net/releases/active.php'), true);
 		foreach ($stable_releases as $major => $major_releases) {
 			foreach ($major_releases as $release) {
 				$version_parts = parseVersion($release['version']);

--- a/scripts/cron/email-assigned
+++ b/scripts/cron/email-assigned
@@ -6,7 +6,7 @@ require __DIR__ . '/../../include/prepend.php';
 /*
   Many times bugs are assigned to humans but not given the 'Assigned' status. Our bug tracker
   is a little odd that way.
-  'No Feedback' was once a part of this, but no longer: http://news.php.net/php.webmaster/8828
+  'No Feedback' was once a part of this, but no longer: https://news.php.net/php.webmaster/8828
 */
 $sql = "SELECT id, package_name, bug_type, sdesc, status, assign, UNIX_TIMESTAMP(ts1) AS ts_opened, UNIX_TIMESTAMP(ts2) AS ts_changed
 		FROM `bugdb`
@@ -49,7 +49,7 @@ function format_email_body($binfos) {
 
 		$links .= " Title: $link_title\r\n";
 		$links .= " Type:  {$binfo['bug_type']} with Status: {$binfo['status']}\r\n";
-		$links .= " Link:  http://bugs.php.net/{$binfo['id']}\r\n\r\n";
+		$links .= " Link:  https://bugs.php.net/{$binfo['id']}\r\n\r\n";
 	}
 
 	$assigned = $binfo['assign'];

--- a/templates/addghpull.php
+++ b/templates/addghpull.php
@@ -45,7 +45,7 @@ if (!$logged_in) {
   </th>
   <td class="form-input">
    <select name="repository" id="repository_field"><option value=""></option></select>
-   <small>The repository must belong to http://github.com/php/.</small>
+   <small>The repository must belong to https://github.com/php</small>
   </td>
  </tr>
  <tr>

--- a/www/bug.php
+++ b/www/bug.php
@@ -665,7 +665,7 @@ if (!$show_bug_info) {
 			<th class="details">Status:</th>
 			<td><?php echo htmlspecialchars($bug['status']); ?></td>
 			<th class="details">Package:</th>
-			<td><a href="search.php?cmd=display&amp;package_name[]=<?php echo urlencode($bug['package_name']), '">', htmlspecialchars($bug['package_name']); ?></a><?php echo $bug['project'] == 'pecl' ? ' (<a href="http://pecl.php.net/package/'. htmlspecialchars($bug['package_name']) . '" target="_blank">PECL</a>)' : ''; ?></td>
+			<td><a href="search.php?cmd=display&amp;package_name[]=<?php echo urlencode($bug['package_name']), '">', htmlspecialchars($bug['package_name']); ?></a><?php echo $bug['project'] == 'pecl' ? ' (<a href="https://pecl.php.net/package/'. htmlspecialchars($bug['package_name']) . '" target="_blank">PECL</a>)' : ''; ?></td>
 		</tr>
 
 		<tr id="situation">
@@ -679,7 +679,7 @@ if (!$show_bug_info) {
 			<th class="details">Private report:</th>
 			<td><?php echo $bug['private'] == 'Y' ? 'Yes' : 'No'; ?></td>
 			<th class="details">CVE-ID:</th>
-			<td><?php if (!empty($bug['cve_id'])) { printf('<a href="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-%s" target="_blank">%1$s</a>', htmlspecialchars($bug['cve_id'])); } else { ?><em>None</em><?php } ?></td>
+			<td><?php if (!empty($bug['cve_id'])) { printf('<a href="https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-%s" target="_blank">%1$s</a>', htmlspecialchars($bug['cve_id'])); } else { ?><em>None</em><?php } ?></td>
 		</tr>
 	</table>
 </div>

--- a/www/bugs-generating-backtrace-win32.php
+++ b/www/bugs-generating-backtrace-win32.php
@@ -16,7 +16,7 @@ backtrace_inline_menu('Windows');
 
 <p>You'll need to install MS Visual Studio 2008, 2012 or later. You'll also need to</p>
 <ul>
-	<li>either download the debug-pack for your PHP version from <a href="http://windows.php.net/download/">http://windows.php.net/download/</a></li>
+	<li>either download the debug-pack for your PHP version from <a href="https://windows.php.net/download/">windows.php.net/download</a></li>
 	<li>or compile your own PHP with <code>--enable-dbg-pack</code> or <code>--enable-debug</code></li>
 </ul>
 
@@ -45,14 +45,14 @@ KERNEL32! 77e81af6()
 </code></pre>
 
 <!--
-	Everything below is stolen from Pierre,
-	http://blog.thepimp.net/index.php/post/2007/06/10/debug-pack-or-how-to-generate-backtrack-on-windows-without-compiling
+	Everything below is stolen from Pierre Joye
+	https://blog.thepimp.net/index.php/post/2007/06/10/debug-pack-or-how-to-generate-backtrack-on-windows-without-compiling
 -->
 <h1>Generating backtrace, <u>without</u> compiler, on Windows</h1>
 <p>You'll need:</p>
 <ul>
-<li>A PHP <a href="http://windows.php.net/downloads/snaps/">snapshot</a> or <a href="http://windows.php.net/download/">stable</a> release</li>
-<li>PHP Debug pack (<a href="http://windows.php.net/downloads/snaps/">snapshot</a> or <a href="http://windows.php.net/download/">stable</a>)</li>
+<li>A PHP <a href="https://windows.php.net/downloads/snaps/">snapshot</a> or <a href="https://windows.php.net/download/">stable</a> release</li>
+<li>PHP Debug pack (<a href="https://windows.php.net/downloads/snaps/">snapshot</a> or <a href="https://windows.php.net/download/">stable</a>)</li>
 <li>Microsoft <a href="https://www.microsoft.com/en-us/download/details.aspx?id=49924">Debug Diagnostic Tools</a></li>
 <li>Evil script to crash PHP</li>
 </ul>

--- a/www/css/style.css
+++ b/www/css/style.css
@@ -784,7 +784,7 @@ td.search-next {
 	background-color: #B5C7CD;
 }
 
-/* {{{ Stolen from http://www.devbridge.com/projects/autocomplete/jquery/ */
+/* {{{ Stolen from https://www.devbridge.com/sourcery/components/jquery-autocomplete/ */
 .autocomplete-w1 {
 	background: url(../images/shadow.png) no-repeat bottom right;
 	position: absolute;

--- a/www/how-to-report.php
+++ b/www/how-to-report.php
@@ -23,7 +23,7 @@ heart a few tips on how to report a bug so that they can and will help you.</p>
 <p>Take special note of that word in bold above. The people who are going to
 help you with a bug you report are <b>volunteers</b>. Not only are you not
 paying them to help you, but nobody else is either. So, to paraphrase the
-immortal words of <a href="http://www.imdb.com/Title?0096928">Bill and Ted</a>,
+immortal words of <a href="https://www.imdb.com/title/tt0096928/">Bill and Ted</a>,
 <b>"be excellent to them"</b>.</p>
 
 <p>Beyond that golden rule, what follows are some additional tips on ways to
@@ -58,7 +58,7 @@ reports.</p>
 <h2>If you don't understand an error message, ask for help.</h2>
 
 <p>Don't report an error message you don't understand as a bug. There are <a
-href="http://www.php.net/support.php">a lot of places you can ask for help</a>
+href="https://php.net/support.php">a lot of places you can ask for help</a>
 in understanding what is going on before you can claim that an error message
 you do not understand is a bug.</p>
 
@@ -101,7 +101,7 @@ many people who can speak a great many languages. But if you were to report a
 bug in a language other than English, many (if not most) of the people who
 would otherwise help you won't be able to. If you're worried about your English
 skills making it difficult to describe the bug, you might try asking for help
-on one of the <a href="http://www.php.net/support.php#local">non-English
+on one of the <a href="https://php.net/support.php#local">non-English
 mailing lists</a>.</p>
 
 <h2>Don't report bugs about old versions.</h2>
@@ -131,7 +131,7 @@ with the different bugs.</p>
 		writing guidelines</a>
 	</li>
 	<li>
-		Simon Tatham's <a href="http://www.chiark.greenend.org.uk/~sgtatham/bugs.html">How
+		Simon Tatham's <a href="https://www.chiark.greenend.org.uk/~sgtatham/bugs.html">How
 		to Report Bugs Effectively</a>
 	</li>
 </ul>

--- a/www/index.php
+++ b/www/index.php
@@ -67,7 +67,7 @@ if (bugid > 0) {
 
 	<li>
 		Make sure it isn't a support question. For support,
-		see the <a href="http://www.php.net/support.php">support page</a>.
+		see the <a href="https://php.net/support.php">support page</a>.
 	</li>
 </ul>
 

--- a/www/js/Markdown.Converter.js
+++ b/www/js/Markdown.Converter.js
@@ -88,7 +88,7 @@ else
     // caused an exception (and hence stopped the rendering) when the user entered
     // e.g. [push] or [__proto__]. Adding a prefix to the actual key prevents this
     // (since no builtin property starts with "s_"). See
-    // http://meta.stackoverflow.com/questions/64655/strange-wmd-bug
+    // https://meta.stackexchange.com/questions/64655/strange-wmd-bug
     // (granted, switching from Array() to Object() alone would have left only __proto__
     // to be a problem)
     function SaveHash() { }
@@ -331,7 +331,7 @@ else
                 [ ]{0,3}                                        // attacklab: g_tab_width - 1
                 (                                               // save in $1
                     <!
-                    (--(?:|(?:[^>-]|-[^>])(?:[^-]|-[^-])*)--)   // see http://www.w3.org/TR/html-markup/syntax.html#comments and http://meta.stackoverflow.com/q/95256
+                    (--(?:|(?:[^>-]|-[^>])(?:[^-]|-[^-])*)--)   // see https://www.w3.org/TR/html/syntax.html#comments and https://meta.stackoverflow.com/q/95256
                     >
                     [ \t]*
                     (?=\n{2,})                                  // followed by a blank line
@@ -421,7 +421,7 @@ else
             text = _DoImages(text);
             text = _DoAnchors(text);
 
-            // Make links out of things like `<http://example.com/>`
+            // Make links out of things like `<https://example.com/>`
             // Must come after _DoAnchors(), because you can use < and >
             // delimiters in inline links like [this](<url>).
             text = _DoAutoLinks(text);
@@ -452,7 +452,7 @@ else
 
             text = text.replace(regex, function (wholeMatch) {
                 var tag = wholeMatch.replace(/(.)<\/?code>(?=.)/g, "$1`");
-                tag = escapeCharacters(tag, wholeMatch.charAt(1) == "!" ? "\\`*_/" : "\\`*_"); // also escape slashes in comments to prevent autolinking there -- http://meta.stackoverflow.com/questions/95987
+                tag = escapeCharacters(tag, wholeMatch.charAt(1) == "!" ? "\\`*_/" : "\\`*_"); // also escape slashes in comments to prevent autolinking there -- https://meta.stackoverflow.com/questions/95987
                 return tag;
             });
 
@@ -760,7 +760,7 @@ else
             //
 
             // attacklab: add sentinel to hack around khtml/safari bug:
-            // http://bugs.webkit.org/show_bug.cgi?id=11231
+            // https://bugs.webkit.org/show_bug.cgi?id=11231
             text += "~0";
 
             // Re-usable pattern to match any entirel ul or ol list:
@@ -1198,13 +1198,13 @@ else
         function _DoAutoLinks(text) {
 
             // note that at this point, all other URL in the text are already hyperlinked as <a href=""></a>
-            // *except* for the <http://www.foo.com> case
+            // *except* for the <https://www.foo.com> case
 
             // automatically add < and > around unadorned raw hyperlinks
             // must be preceded by space/BOF and followed by non-word/EOF character
             text = text.replace(/(^|\s)(https?|ftp)(:\/\/[-A-Z0-9+&@#\/%?=~_|\[\]\(\)!:,\.;]*[-A-Z0-9+&@#\/%=~_|\[\]])($|\W)/gi, "$1<$2$3>$4");
 
-            //  autolink anything like <http://example.com>
+            //  autolink anything like <https://example.com>
 
             var replacer = function (wholematch, m1) { return "<a href=\"" + m1 + "\">" + pluginHooks.plainLinkText(m1) + "</a>"; }
             text = text.replace(/<((https?|ftp):[^'">\s]+)>/gi, replacer);

--- a/www/report.php
+++ b/www/report.php
@@ -342,7 +342,7 @@ if (!isset($_POST['in'])) {
 			 'bug_type' => isset($_GET['bug_type']) ? clean($_GET['bug_type']) : '',
 			 'email' => '',
 			 'sdesc' => '',
-			 'ldesc' => isset($_GET['manpage']) ? clean("\n---\nFrom manual page: http://www.php.net/" . ltrim($_GET['manpage'], '/') . "\n---\n") : '',
+			 'ldesc' => isset($_GET['manpage']) ? clean("\n---\nFrom manual page: https://php.net/" . ltrim($_GET['manpage'], '/') . "\n---\n") : '',
 			 'repcode' => '',
 			 'expres' => '',
 			 'actres' => '',
@@ -362,14 +362,14 @@ if (!isset($_POST['in'])) {
 
 	<p>
 		If you aren't sure that what you're about to report is a bug, you should ask for help using one of the means for support
-		<a href="http://www.php.net/support.php">listed here</a>.
+		<a href="https://php.net/support.php">listed here</a>.
 	</p>
 
 	<p>
 		<strong>Failure to follow these instructions may result in your bug simply being marked as &quot;not a bug.&quot;</strong>
 	</p>
 
-	<p>Report <img src="images/pear_item.gif"><b>PEAR</b> related bugs <a href="http://pear.php.net/bugs/">here</a></p>
+	<p>Report <img src="images/pear_item.gif"><b>PEAR</b> related bugs <a href="https://pear.php.net/bugs/">here</a></p>
 
 	<p>
 		<strong>If you feel this bug concerns a security issue, e.g. a buffer overflow, weak encryption, etc, then email


### PR DESCRIPTION
Changes:
- http links updated to https (those that work so far)
- us3.php.net mirror changed to php.net for fetching PHP versions
- some outdated links refreshed