### PR TITLE
Refactor long array() syntax to short []

### DIFF
--- a/include/classes/bug_ghpulltracker.php
+++ b/include/classes/bug_ghpulltracker.php
@@ -13,12 +13,12 @@ class Bug_Pulltracker
 
 	private function getDataFromGithub($repo, $pull_id)
 	{
-		$ctxt = stream_context_create(array(
-			'http' => array(
+		$ctxt = stream_context_create([
+			'http' => [
 				'ignore_errors' => '1',
 				'user_agent' => $this->userAgent,
-			)
-		));
+			]
+		]);
 		$data = @json_decode(file_get_contents("https://api.github.com/repos/php/".urlencode($repo).'/pulls/'.((int)$pull_id), null, $ctxt));
 		if (!is_object($data)) {
 			return false;
@@ -38,7 +38,7 @@ class Bug_Pulltracker
 		PEAR::pushErrorHandling(PEAR_ERROR_RETURN);
 		$e = $this->_dbh->prepare('INSERT INTO bugdb_pulls
 			(bugdb_id, github_repo, github_pull_id, github_title, github_html_url, developer) VALUES (?, ?, ?, ?, ?, ?)')->execute(
-				array($bugid, $repo, $pull_id, $data->title, $data->html_url, $developer));
+				[$bugid, $repo, $pull_id, $data->title, $data->html_url, $developer]);
 		PEAR::popErrorHandling();
 		if (PEAR::isError($e)) {
 			return $e;
@@ -54,7 +54,7 @@ class Bug_Pulltracker
 	{
 		$this->_dbh->prepare('DELETE FROM bugdb_pulls
 			WHERE bugdb_id = ? and github_repo = ? and github_pull_id = ?')->execute(
-			array($bugid, $repo, $pull_id));
+			[$bugid, $repo, $pull_id]);
 	}
 
 	/**
@@ -72,6 +72,6 @@ class Bug_Pulltracker
 			ORDER BY github_repo, github_pull_id DESC
 		';
 
-		return $this->_dbh->prepare($query)->execute(array($bugid))->fetchAll(PDO::FETCH_ASSOC);
+		return $this->_dbh->prepare($query)->execute([$bugid])->fetchAll(PDO::FETCH_ASSOC);
 	}
 }

--- a/include/classes/bug_patchtracker.php
+++ b/include/classes/bug_patchtracker.php
@@ -76,19 +76,19 @@ class Bug_Patchtracker
 		PEAR::pushErrorHandling(PEAR_ERROR_RETURN);
 		$e = $this->_dbh->prepare('INSERT INTO bugdb_patchtracker
 			(bugdb_id, patch, revision, developer) VALUES(?, ?, ?, ?)')->execute(
-			array($bugid, $patch, $id, $handle));
+			[$bugid, $patch, $id, $handle]);
 		if (PEAR::isError($e)) {
 			// try with another timestamp
 			$id++;
 			$e = $this->_dbh->prepare('INSERT INTO bugdb_patchtracker
 				(bugdb_id, patch, revision, developer) VALUES(?, ?, ?, ?)')->execute(
-				array($bugid, $patch, $id, $handle));
+				[$bugid, $patch, $id, $handle]);
 		}
 		PEAR::popErrorHandling();
 		if (PEAR::isError($e)) {
 			return PEAR::raiseError("Could not get unique patch file name for bug #{$bugid}, patch \"{$patch}\"");
 		}
-		return array($id, $this->getPatchFileName($id));
+		return [$id, $this->getPatchFileName($id)];
 	}
 
 	/**
@@ -144,7 +144,7 @@ class Bug_Patchtracker
 		}
 
 		if ($file->isValid()) {
-			$newobsoletes = array();
+			$newobsoletes = [];
 			foreach ($obsoletes as $who) {
 				if (!$who) {
 					continue; // remove (none)
@@ -167,7 +167,7 @@ class Bug_Patchtracker
 			}
 			list($id, $fname) = $res;
 			$file->setName($fname);
-			$allowed_mime_types = array(
+			$allowed_mime_types = [
 				'application/x-txt',
 				'text/plain',
 				'text/x-diff',
@@ -175,7 +175,7 @@ class Bug_Patchtracker
 				'text/x-c++',
 				'text/x-c',
 				'text/x-m4',
-			);
+			];
 
 			// return mime type ala mimetype extension
 			if (class_exists('finfo')) {
@@ -197,7 +197,7 @@ class Bug_Patchtracker
 			if (!in_array($mime, $allowed_mime_types)) {
 				$this->_dbh->prepare('DELETE FROM bugdb_patchtracker
 					WHERE bugdb_id = ? and patch = ? and revision = ?')->execute(
-					array($bugid, $name, $id));
+					[$bugid, $name, $id]);
 				return PEAR::raiseError('Error: uploaded patch file must be text'
 					. ' file (save as e.g. "patch.txt" or "package.diff")'
 					. ' (detected "' . htmlspecialchars($mime) . '")'
@@ -207,7 +207,7 @@ class Bug_Patchtracker
 			if (PEAR::isError($tmpfile)) {
 				$this->_dbh->prepare('DELETE FROM bugdb_patchtracker
 					WHERE bugdb_id = ? and patch = ? and revision = ?')->execute(
-					array($bugid, $name, $id));
+					[$bugid, $name, $id]);
 				return $tmpfile;
 			}
 			if (!$file->getProp('size')) {
@@ -241,7 +241,7 @@ class Bug_Patchtracker
 	{
 		$this->_dbh->prepare('DELETE FROM bugdb_patchtracker
 			WHERE bugdb_id = ? and patch = ? and revision = ?')->execute(
-			array($bugid, $name, $revision));
+			[$bugid, $name, $revision]);
 		@unlink($this->patchDir($bugid, $name) . DIRECTORY_SEPARATOR .
 			$this->getPatchFileName($revision));
 	}
@@ -259,7 +259,7 @@ class Bug_Patchtracker
 		if ($this->_dbh->prepare('
 			SELECT bugdb_id
 			FROM bugdb_patchtracker
-			WHERE bugdb_id = ? AND patch = ? AND revision = ?')->execute(array($bugid, $name, $revision))->fetchOne()
+			WHERE bugdb_id = ? AND patch = ? AND revision = ?')->execute([$bugid, $name, $revision])->fetchOne()
 		) {
 			$contents = @file_get_contents($this->getPatchFullpath($bugid, $name, $revision));
 			if (!$contents) {
@@ -285,7 +285,7 @@ class Bug_Patchtracker
 			ORDER BY revision DESC
 		';
 
-		return $this->_dbh->prepare($query)->execute(array($bugid))->fetchAll(PDO::FETCH_NUM, true, false, true);
+		return $this->_dbh->prepare($query)->execute([$bugid])->fetchAll(PDO::FETCH_NUM, true, false, true);
 	}
 
 	/**
@@ -302,7 +302,7 @@ class Bug_Patchtracker
 			WHERE bugdb_id = ? AND patch = ?
 			ORDER BY revision DESC
 		';
-		return $this->_dbh->prepare($query)->execute(array($bugid, $patch))->fetchAll(PDO::FETCH_NUM);
+		return $this->_dbh->prepare($query)->execute([$bugid, $patch])->fetchAll(PDO::FETCH_NUM);
 	}
 
 	/**
@@ -320,13 +320,13 @@ class Bug_Patchtracker
 				SELECT developer
 				FROM bugdb_patchtracker
 				WHERE bugdb_id = ? AND patch = ? AND revision = ?
-			')->execute(array($bugid, $patch, $revision))->fetchOne();
+			')->execute([$bugid, $patch, $revision])->fetchOne();
 		}
 		return $this->_dbh->prepare('
 			SELECT developer, revision
 			FROM bugdb_patchtracker
 			WHERE bugdb_id = ? AND patch = ? ORDER BY revision DESC
-		')->execute(array($bugid, $patch))->fetchAll(PDO::FETCH_ASSOC);
+		')->execute([$bugid, $patch])->fetchAll(PDO::FETCH_ASSOC);
 	}
 
 	function getObsoletingPatches($bugid, $patch, $revision)
@@ -335,7 +335,7 @@ class Bug_Patchtracker
 			SELECT bugdb_id, patch, revision
 			FROM bugdb_obsoletes_patches
 			WHERE	bugdb_id = ? AND obsolete_patch = ? AND obsolete_revision = ?
-		')->execute(array($bugid, $patch, $revision))->fetchAll(PDO::FETCH_ASSOC);
+		')->execute([$bugid, $patch, $revision])->fetchAll(PDO::FETCH_ASSOC);
 	}
 
 	function getObsoletePatches($bugid, $patch, $revision)
@@ -344,7 +344,7 @@ class Bug_Patchtracker
 			SELECT bugdb_id, obsolete_patch, obsolete_revision
 			FROM bugdb_obsoletes_patches
 			WHERE bugdb_id = ? AND patch = ? AND revision = ?
-		')->execute(array($bugid, $patch, $revision))->fetchAll(PDO::FETCH_ASSOC);
+		')->execute([$bugid, $patch, $revision])->fetchAll(PDO::FETCH_ASSOC);
 	}
 
 	/**
@@ -361,6 +361,6 @@ class Bug_Patchtracker
 		$this->_dbh->prepare('
 			INSERT INTO bugdb_obsoletes_patches
 			VALUES(?, ?, ?, ?, ?)
-		')->execute(array($bugid, $name, $revision, $obsoletename, $obsoleterevision));
+		')->execute([$bugid, $name, $revision, $obsoletename, $obsoleterevision]);
 	}
 }

--- a/include/functions.php
+++ b/include/functions.php
@@ -9,7 +9,7 @@ define('BUGS_SECURITY_DEV', 1<<3);
 /* Contains functions and variables used throughout the bug system */
 
 // used in mail_bug_updates(), below, and class for search results
-$tla = array(
+$tla = [
 	'Open'          => 'Opn',
 	'Not a bug'     => 'Nab',
 	'Feedback'      => 'Fbk',
@@ -24,22 +24,22 @@ $tla = array(
 	'Closed'        => 'Csd',
 	'Spam'          => 'Spm',
 	'Re-Opened'     => 'ReO',
-);
+];
 
-$bug_types = array(
+$bug_types = [
 	'Bug'                      => 'Bug',
 	'Feature/Change Request'   => 'Req',
 	'Documentation Problem'    => 'Doc',
 	'Security'                 => 'Sec Bug'
-);
+];
 
-$project_types = array(
+$project_types = [
 	'PHP'   => 'php',
 	'PECL'  => 'pecl'
-);
+];
 
 // Used in show_state_options()
-$state_types = array (
+$state_types = [
 	'Open'          => 2,
 	'Closed'        => 2,
 	'Re-Opened'     => 1,
@@ -59,7 +59,7 @@ $state_types = array (
 	'Not a bug'     => 1,
 	'Spam'          => 1,
 	'All'           => 0,
-);
+];
 
 /**
  * Authentication
@@ -69,20 +69,20 @@ function verify_user_password($user, $pass)
 	global $errors;
 
 	$post = http_build_query(
-		array(
+		[
 			'token' => getenv('AUTH_TOKEN'),
 			'username' => $user,
 			'password' => $pass,
-		)
+		]
 	);
 
-	$opts = array(
+	$opts = [
 		'method'	=> 'POST',
 		'header'	=> 'Content-type: application/x-www-form-urlencoded',
 		'content'	=> $post,
-	);
+	];
 
-	$ctx = stream_context_create(array('http' => $opts));
+	$ctx = stream_context_create(['http' => $opts]);
 
 	$s = file_get_contents('https://master.php.net/fetch/cvsauth.php', false, $ctx);
 
@@ -204,7 +204,7 @@ function get_pseudo_packages($project, $return_disabled = true)
 {
 	global $dbh, $project_types;
 
-	$pseudo_pkgs = $nodes = $tree = array();
+	$pseudo_pkgs = $nodes = $tree = [];
 	$where = '1=1';
 	$project = strtolower($project);
 
@@ -220,7 +220,7 @@ function get_pseudo_packages($project, $return_disabled = true)
 	// Convert flat array to nested strucutre
 	foreach ($data as &$node)
 	{
-		$node['children'] = array();
+		$node['children'] = [];
 		$id = $node['id'];
 		$parent_id = $node['parent'];
 		$nodes[$id] =& $node;
@@ -235,21 +235,21 @@ function get_pseudo_packages($project, $return_disabled = true)
 	foreach ($tree as $data)
 	{
 		if (isset($data['children'])) {
-			$pseudo_pkgs[$data['name']] = array($data['long_name'], $data['disabled'], array());
+			$pseudo_pkgs[$data['name']] = [$data['long_name'], $data['disabled'], []];
 			$children = &$pseudo_pkgs[$data['name']][2];
-			$long_names = array();
+			$long_names = [];
 			foreach ($data['children'] as $k => $v) {
 				$long_names[$k] = strtolower($v['long_name']);
 			}
 			array_multisort($long_names, SORT_ASC, SORT_STRING, $data['children']);
 			foreach ($data['children'] as $child)
 			{
-				$pseudo_pkgs[$child['name']] = array("{$child['long_name']}", $child['disabled'], null);
+				$pseudo_pkgs[$child['name']] = ["{$child['long_name']}", $child['disabled'], null];
 				$children[] = $child['name'];
 			}
 
 		} elseif (!isset($pseudo_pkgs[$data['name']])) {
-			$pseudo_pkgs[$data['name']] = array($data['long_name'], $data['disabled'], null);
+			$pseudo_pkgs[$data['name']] = [$data['long_name'], $data['disabled'], null];
 		}
 	}
 
@@ -268,7 +268,7 @@ function is_spam($string)
 		return true;
 	}
 
-	$keywords = array(
+	$keywords = [
 		'spy',
 		'bdsm',
 		'massage',
@@ -303,7 +303,7 @@ function is_spam($string)
 		'jerseys',
 		'wholesale',
 		'fashionretailshop01',
-	);
+	];
 
 	if (preg_match('/\b('. implode('|', $keywords) . ')\b/i', $string)) {
 		return true;
@@ -331,15 +331,15 @@ function spam_protect($txt, $format = 'html')
 		return $txt;
 	}
 	if ($format == 'html') {
-		$translate = array(
+		$translate = [
 			'@' => ' &#x61;&#116; ',
 			'.' => ' &#x64;&#111;&#x74; ',
-		);
+		];
 	} else {
-		$translate = array(
+		$translate = [
 			'@' => ' at ',
 			'.' => ' dot ',
-		);
+		];
 		if ($format == 'reverse') {
 			$translate = array_flip($translate);
 		}
@@ -361,7 +361,7 @@ function escapeSQL($in)
 	global $dbh;
 
 	if (is_array($in)) {
-		$out = array();
+		$out = [];
 		foreach ($in as $key => $value) {
 			$out[$key] = $dbh->escape($value);
 		}
@@ -424,7 +424,7 @@ function field($n)
 function clean($in)
 {
 	return mb_encode_numericentity($in,
-		array(
+		[
 			0x0, 0x8, 0, 0xffffff,
 			0xb, 0xc, 0, 0xffffff,
 			0xe, 0x1f, 0, 0xffffff,
@@ -451,7 +451,7 @@ function clean($in)
 			0xefffe, 0xeffff, 0, 0xffffff,
 			0xffffe, 0xfffff, 0, 0xffffff,
 			0x10fffe, 0x10ffff, 0, 0xffffff,
-		),
+		],
 	'UTF-8');
 }
 
@@ -490,14 +490,14 @@ function txfield($n, $bug = null, $in = null)
  */
 function show_byage_options($current)
 {
-	$opts = array(
+	$opts = [
 		'0' => 'the beginning',
 		'1'	=> 'yesterday',
 		'7'	=> '7 days ago',
 		'15' => '15 days ago',
 		'30' => '30 days ago',
 		'90' => '90 days ago',
-	);
+	];
 	while (list($k,$v) = each($opts)) {
 		echo "<option value=\"$k\"", ($current==$k ? ' selected="selected"' : ''), ">$v</option>\n";
 	}
@@ -783,7 +783,7 @@ function show_package_options($current, $show_any, $default = '')
  */
 function show_boolean_options($current)
 {
-	$options = array('any', 'all', 'raw');
+	$options = ['any', 'all', 'raw'];
 	while (list($val, $type) = each($options)) {
 		echo '<input type="radio" name="boolean" value="', $val, '"';
 		if ($val === $current) {
@@ -813,7 +813,7 @@ function show_boolean_options($current)
 function display_bug_error($in, $class = 'errors', $head = 'ERROR:')
 {
 	if (!is_array($in)) {
-		$in = array($in);
+		$in = [$in];
 	} elseif (!count($in)) {
 		return false;
 	}
@@ -843,14 +843,14 @@ function display_bug_success($in)
  */
 function bug_diff($bug, $in)
 {
-	$changed = array();
+	$changed = [];
 
 	if (!empty($in['email']) && (trim($in['email']) != trim($bug['email']))) {
 		$changed['reported_by']['from'] = spam_protect($bug['email'], 'text');
 		$changed['reported_by']['to'] = spam_protect(txfield('email', $bug, $in), 'text');
 	}
 
-	$fields = array(
+	$fields = [
 		'sdesc'				=> 'Summary',
 		'status'			=> 'Status',
 		'bug_type'			=> 'Type',
@@ -861,14 +861,14 @@ function bug_diff($bug, $in)
 		'block_user_comment' => 'Block user comment',
 		'private'			=> 'Private report',
 		'cve_id'			=> 'CVE-ID'
-	);
+	];
 
 	foreach (array_keys($fields) as $name) {
 		if (array_key_exists($name, $in) && array_key_exists($name, $bug)) {
 			$to   = trim($in[$name]);
 			$from = trim($bug[$name]);
 			if ($from != $to) {
-				if (in_array($name, array('private', 'block_user_comment'))) {
+				if (in_array($name, ['private', 'block_user_comment'])) {
 					$from = $from == 'Y' ? 'Yes' : 'No';
 					$to = $to == 'Y' ? 'Yes' : 'No';
 				}
@@ -883,7 +883,7 @@ function bug_diff($bug, $in)
 
 function bug_diff_render_html($diff)
 {
-	$fields = array(
+	$fields = [
 		'sdesc'				=> 'Summary',
 		'status'			=> 'Status',
 		'bug_type'			=> 'Type',
@@ -894,7 +894,7 @@ function bug_diff_render_html($diff)
 		'block_user_comment' => 'Block user comment',
 		'private'			=> 'Private report',
 		'cve_id'			=> 'CVE-ID'
-	);
+	];
 
 	// make diff output aligned
 	$actlength = $maxlength = 0;
@@ -932,35 +932,35 @@ function mail_bug_updates($bug, $in, $from, $ncomment, $edit = 1, $id = false)
 {
 	global $tla, $bug_types, $siteBig, $site_method, $site_url, $basedir;
 
-	$text = array();
-	$headers = array();
+	$text = [];
+	$headers = [];
 	$changed = bug_diff($bug, $in);
-	$from = str_replace(array("\n", "\r"), '', $from);
+	$from = str_replace(["\n", "\r"], '', $from);
 
 	/* Default addresses */
 	list($mailto, $mailfrom, $bcc, $params) = get_package_mail(oneof(@$in['package_name'], $bug['package_name']), $id, oneof(@$in['bug_type'], $bug['bug_type']));
 
-	$headers[] = array(' ID', $bug['id']);
+	$headers[] = [' ID', $bug['id']];
 
 	switch ($edit) {
 		case 4:
-			$headers[] = array(' Patch added by', $from);
+			$headers[] = [' Patch added by', $from];
 			$from = "\"{$from}\" <{$mailfrom}>";
 			break;
 		case 3:
-			$headers[] = array(' Comment by', $from);
+			$headers[] = [' Comment by', $from];
 			$from = "\"{$from}\" <{$mailfrom}>";
 			break;
 		case 2:
 			$from = spam_protect(txfield('email', $bug, $in), 'text');
-			$headers[] = array(' User updated by', $from);
+			$headers[] = [' User updated by', $from];
 			$from = "\"{$from}\" <{$mailfrom}>";
 			break;
 		default:
-			$headers[] = array(' Updated by', $from);
+			$headers[] = [' Updated by', $from];
 	}
 
-	$fields = array(
+	$fields = [
 		'email'				=> 'Reported by',
 		'sdesc'				=> 'Summary',
 		'status'			=> 'Status',
@@ -972,12 +972,12 @@ function mail_bug_updates($bug, $in, $from, $ncomment, $edit = 1, $id = false)
 		'block_user_comment' => 'Block user comment',
 		'private'			=> 'Private report',
 		'cve_id'			=> 'CVE-ID',
-	);
+	];
 
 	foreach ($fields as $name => $desc) {
 		$prefix = ' ';
 		if (isset($changed[$name])) {
-			$headers[] = array("-{$desc}", $changed[$name]['from']);
+			$headers[] = ["-{$desc}", $changed[$name]['from']];
 			$prefix = '+';
 		}
 
@@ -987,7 +987,7 @@ function mail_bug_updates($bug, $in, $from, $ncomment, $edit = 1, $id = false)
 				$f = spam_protect($f, 'text');
 			}
 			$foo = isset($changed[$name]['to']) ? $changed[$name]['to'] : $f;
-			$headers[] = array($prefix.$desc, $foo);
+			$headers[] = [$prefix.$desc, $foo];
 		}
 	}
 
@@ -1092,7 +1092,7 @@ DEV_TEXT;
 		$tmp = $edit != 3 ? $in : $bug;
 		$tmp['new_status'] = $new_status;
 		$tmp['old_status'] = $old_status;
-		foreach (array('bug_type', 'php_version', 'package_name', 'php_os') as $field) {
+		foreach (['bug_type', 'php_version', 'package_name', 'php_os'] as $field) {
 			$tmp[$field] = strtok($tmp[$field], "\r\n");
 		}
 
@@ -1285,7 +1285,7 @@ function incoming_details_are_valid($in, $initial = 0, $logged_in = false)
 {
 	global $bug, $dbh, $bug_types, $versions;
 
-	$errors = array();
+	$errors = [];
 	if (!is_array($in)) {
 		$errors[] = 'Invalid data submitted!';
 		return $errors;
@@ -1339,7 +1339,7 @@ function get_package_mail($package_name, $bug_id = false, $bug_type = 'Bug')
 {
 	global $dbh, $bugEmail, $docBugEmail, $secBugEmail, $security_distro_people;
 
-	$to = array();
+	$to = [];
 	$params = '-f noreply@php.net';
 	$mailfrom = $bugEmail;
 
@@ -1406,9 +1406,9 @@ function get_package_mail($package_name, $bug_id = false, $bug_type = 'Bug')
 		$bcc = $dbh->prepare("SELECT email FROM bugdb_subscribe WHERE bug_id=?")->execute([$bug_id])->fetchAll();
 
 		$bcc = array_unique($bcc);
-		return array(implode(', ', $to), $mailfrom, implode(', ', $bcc), $params);
+		return [implode(', ', $to), $mailfrom, implode(', ', $bcc), $params];
 	} else {
-		return array(implode(', ', $to), $mailfrom, '', $params);
+		return [implode(', ', $to), $mailfrom, '', $params];
 	}
 }
 
@@ -1426,7 +1426,7 @@ function format_search_string($search, $boolean_search = false)
 	$min_word_len=3;
 
 	$words = preg_split("/\s+/", $search);
-	$ignored = $used = array();
+	$ignored = $used = [];
 	foreach($words as $match)
 	{
 		if (strlen($match) < $min_word_len) {
@@ -1443,15 +1443,15 @@ function format_search_string($search, $boolean_search = false)
 			foreach ($used as $word) {
 				$newsearch .= "+$word ";
 			}
-			return array(" AND MATCH (bugdb.email,sdesc,ldesc) AGAINST ('" . escapeSQL($newsearch) . "' IN BOOLEAN MODE)", $ignored);
+			return [" AND MATCH (bugdb.email,sdesc,ldesc) AGAINST ('" . escapeSQL($newsearch) . "' IN BOOLEAN MODE)", $ignored];
 
 		// allow custom boolean search (raw)
 		} elseif ($boolean_search === 2) {
-			return array(" AND MATCH (bugdb.email,sdesc,ldesc) AGAINST ('" . escapeSQL($search) . "' IN BOOLEAN MODE)", $ignored);
+			return [" AND MATCH (bugdb.email,sdesc,ldesc) AGAINST ('" . escapeSQL($search) . "' IN BOOLEAN MODE)", $ignored];
 		}
 	}
 	// require any of the words (any)
-	return array(" AND MATCH (bugdb.email,sdesc,ldesc) AGAINST ('" . escapeSQL($search) . "')", $ignored);
+	return [" AND MATCH (bugdb.email,sdesc,ldesc) AGAINST ('" . escapeSQL($search) . "')", $ignored];
 }
 
 /**
@@ -1568,8 +1568,8 @@ function get_resolve_reasons($project = false)
 		$where.= "WHERE (project = '{$project}' OR project = '')";
 	}
 
-	$resolves = $variations = array();
-	$res = $dbh->prepare("SELECT * FROM bugdb_resolves $where")->execute(array());
+	$resolves = $variations = [];
+	$res = $dbh->prepare("SELECT * FROM bugdb_resolves $where")->execute([]);
 	if (!$res) {
 		throw new Exception("SQL Error in get_resolve_reasons");
 	}
@@ -1580,7 +1580,7 @@ function get_resolve_reasons($project = false)
 			$resolves[$row['name']] = $row;
 		}
 	}
-	return array($resolves, $variations);
+	return [$resolves, $variations];
 }
 
 /**
@@ -1641,9 +1641,9 @@ function bugs_add_comment($bug_id, $from, $from_name, $comment, $type = 'comment
 	return $dbh->prepare("
 		INSERT INTO bugdb_comments (bug, email, reporter_name, comment, comment_type, ts, visitor_ip)
 		VALUES (?, ?, ?, ?, ?, NOW(), INET6_ATON(?))
-	")->execute(array(
+	")->execute([
 		$bug_id, $from, $from_name, $comment, $type, (!empty($_SERVER['REMOTE_ADDR'])?$_SERVER['REMOTE_ADDR']:'127.0.0.1')
-	));
+	]);
 }
 
 /**
@@ -1878,7 +1878,7 @@ function make_ticket_links($text)
 
 function get_ticket_links($text)
 {
-	$matches = array();
+	$matches = [];
 
 	preg_match_all('/(?<![>a-z])(?:bug(?:fix)?|feat(?:ure)?|doc(?:umentation)?|req(?:uest)?|duplicated of)\s+#?([0-9]+)/i', $text, $matches);
 

--- a/include/php_versions.php
+++ b/include/php_versions.php
@@ -12,11 +12,11 @@
 	*/
 
 	// Custom versions appended to the list
-	$custom_versions = array(
+	$custom_versions = [
 		'Next Major Version',
 		'Next Minor Version',
 		'Irrelevant'
-	);
+	];
 
 	if(!file_exists("/tmp/versions.php") || filemtime("/tmp/versions.php") < $_SERVER['REQUEST_TIME'] - 3600) {
 		$versions = buildVersions();
@@ -31,13 +31,13 @@
 	function buildVersions() {
 		$dev_versions = json_decode(file_get_contents('https://qa.php.net/api.php?type=qa-releases&format=json&only=dev_versions'));
 
-		$versions = array();
+		$versions = [];
 
 		$date = date('Y-m-d');
-		$default_versions = array(
+		$default_versions = [
 			"Git-{$date} (snap)",
 			"Git-{$date} (Git)",
-		);
+		];
 
 		foreach ($dev_versions as $dev_version) {
 			$dev_version_parts = parseVersion($dev_version);
@@ -45,7 +45,7 @@
 			// if it is a dev version, then add that branch, add the minor-1 version, if it's appropriate
 			if ($dev_version_parts['type'] == 'dev') {
 				if (!isset($versions[$dev_version_parts['major']][$dev_version_parts['minor']])) {
-					$versions[$dev_version_parts['major']][$dev_version_parts['minor']] = array();
+					$versions[$dev_version_parts['major']][$dev_version_parts['minor']] = [];
 				}
 			}
 			// then it is a qa version (alpha|beta|rc)
@@ -64,7 +64,7 @@
 			}
 		}
 
-		$flat_versions = array();
+		$flat_versions = [];
 
 		// add master to the end of the list
 		foreach ($default_versions as $default_version) {
@@ -92,16 +92,16 @@
 
 
 	function parseVersion($version){
-		$version_parts	= array();
-		$raw_parts	= array();
+		$version_parts	= [];
+		$raw_parts	= [];
 		preg_match('#(?P<major>\d+)\.(?P<minor>\d+).(?P<micro>\d+)[-]?(?P<type>RC|alpha|beta|dev)?(?P<number>[\d]?).*#ui', $version, $raw_parts);
-		$version_parts = array(
+		$version_parts = [
 			'major'			=> $raw_parts['major'],
 			'minor'			=> $raw_parts['minor'],
 			'micro'			=> $raw_parts['micro'],
 			'type'			=> strtolower($raw_parts['type']?$raw_parts['type']:'stable'),
 			'number'		=> $raw_parts['number'],
 			'original_version'	=> $version,
-		);
+		];
 		return $version_parts;
 	}

--- a/include/prepend.php
+++ b/include/prepend.php
@@ -10,7 +10,7 @@ $local_cfg = "{$ROOT_DIR}/local_config.php";
 if (file_exists($local_cfg)) {
 	require $local_cfg;
 } else {
-	$site_data = array (
+	$site_data = [
 		'method' => 'https',
 		'url' => 'bugs.php.net',
 		'basedir' => '',
@@ -22,7 +22,7 @@ if (file_exists($local_cfg)) {
 		'db_pass' => '',
 		'db_host' => 'localhost',
 		'patch_tmp' => "{$ROOT_DIR}/uploads/patches/",
-	);
+	];
 	define('DEVBOX', false);
 }
 // CONFIG END

--- a/include/query.php
+++ b/include/query.php
@@ -1,8 +1,8 @@
 <?php
 
-$errors = array();
-$warnings = array();
-$order_options = array(
+$errors = [];
+$warnings = [];
+$order_options = [
 	''				=> 'relevance',
 	'id'			=> 'ID',
 	'ts1'			=> 'date',
@@ -17,7 +17,7 @@ $order_options = array(
 	'avg_score'		=> 'avg. vote score',
 	'votes_count'	=> 'number of votes',
 	'RAND()'	=> 'random',
-);
+];
 
 // Fetch pseudo packages
 $pseudo_pkgs = get_pseudo_packages(false);
@@ -48,8 +48,8 @@ $order_by = (!empty($_GET['order_by']) && array_key_exists($_GET['order_by'], $o
 $reorder_by = (!empty($_GET['reorder_by']) && array_key_exists($_GET['reorder_by'], $order_options)) ? $_GET['reorder_by'] : '';
 $assign = !empty($_GET['assign']) ? $_GET['assign'] : '';
 $author_email = !empty($_GET['author_email']) ? spam_protect($_GET['author_email'], 'reverse') : '';
-$package_name = (isset($_GET['package_name']) && is_array($_GET['package_name'])) ? $_GET['package_name'] : array();
-$package_nname = (isset($_GET['package_nname']) && is_array($_GET['package_nname'])) ? $_GET['package_nname'] : array();
+$package_name = (isset($_GET['package_name']) && is_array($_GET['package_name'])) ? $_GET['package_name'] : [];
+$package_nname = (isset($_GET['package_nname']) && is_array($_GET['package_nname'])) ? $_GET['package_nname'] : [];
 $commented_by = !empty($_GET['commented_by']) ? spam_protect($_GET['commented_by'], 'reverse') : '';
 
 if (isset($_GET['cmd']) && $_GET['cmd'] == 'display')
@@ -63,7 +63,7 @@ if (isset($_GET['cmd']) && $_GET['cmd'] == 'display')
 		FROM bugdb
 	';
 
-	if (in_array($order_by, array('votes_count', 'avg_score'))) {
+	if (in_array($order_by, ['votes_count', 'avg_score'])) {
 		$query .= 'LEFT JOIN bugdb_votes v ON bugdb.id = v.bug';
 	}
 
@@ -229,23 +229,23 @@ if (isset($_GET['cmd']) && $_GET['cmd'] == 'display')
 		}
 	}
 
-	$order_by_clauses = array();
-	if (in_array($order_by, array('votes_count', 'avg_score'))) {
+	$order_by_clauses = [];
+	if (in_array($order_by, ['votes_count', 'avg_score'])) {
 		$query .= ' GROUP BY bugdb.id';
 
 		switch ($order_by) {
 			case 'avg_score':
-				$order_by_clauses = array(
+				$order_by_clauses = [
 					"IFNULL(AVG(v.score), 0)+3 $direction",
 					"COUNT(v.bug) DESC"
-				);
+				];
 				break;
 			case 'votes_count':
-				$order_by_clauses = array("COUNT(v.bug) $direction");
+				$order_by_clauses = ["COUNT(v.bug) $direction"];
 				break;
 		}
 	} elseif ($order_by != '') {
-		$order_by_clauses = array("$order_by $direction");
+		$order_by_clauses = ["$order_by $direction"];
 	}
 
 	if ($status == 'Feedback') {

--- a/include/trusted-devs.php
+++ b/include/trusted-devs.php
@@ -1,6 +1,6 @@
 <?php
 
-$trusted_developers = array(
+$trusted_developers = [
 	'tony2001',
 	'derick',
 	'iliaa',
@@ -19,10 +19,10 @@ $trusted_developers = array(
 	'kalle',
 	'danbrown',
 	'nikic',
-);
+];
 
 // Distro people (security related)
-$security_distro_people = array(
+$security_distro_people = [
 	'jorton',    /* RH */
 	'huzaifas',  /* RH */
 	'vdanen',    /* RH */
@@ -32,9 +32,9 @@ $security_distro_people = array(
 	'sbeattie',  /* Ubuntu */
 	'remi',      /* fedora */
 	'olemarkus', /* Gentoo */
-);
+];
 
-$security_developers = array(
+$security_developers = [
 	'felipe',
 	'rasmus',
 	'tony2001',
@@ -70,6 +70,6 @@ $security_developers = array(
 	'cmb',
 	'danbrown',
 	'yohgaki'
-);
+];
 
 $security_developers = array_merge($security_developers, $security_distro_people);

--- a/local_config.php.sample
+++ b/local_config.php.sample
@@ -4,7 +4,7 @@
  * Add your local changes here and copy to local_config.php
  */
 
-$site_data = array (
+$site_data = [
 	'method' => 'https',
 	'url' => 'bugs.php.net',
 	'basedir' => '/bugs',
@@ -16,6 +16,6 @@ $site_data = array (
 	'db_pass' => '',
 	'db_host' => 'localhost',
 	'patch_tmp' => "{$ROOT_DIR}/uploads/patches/",
-);
+];
 
 define('DEVBOX', true);

--- a/scripts/cron/no-feedback
+++ b/scripts/cron/no-feedback
@@ -9,7 +9,7 @@ require __DIR__.'/../../include/prepend.php';
 $after = "7 DAY";
 
 # Set "input" array
-$in = array('status' => 'No Feedback');
+$in = ['status' => 'No Feedback'];
 
 # Update relevant reports
 if ($dbh)
@@ -22,7 +22,7 @@ if ($dbh)
 			private, reporter_name, UNIX_TIMESTAMP(ts2) AS modified
 		FROM bugdb
 		WHERE status = 'Feedback' AND ts2 < DATE_SUB(NOW(), INTERVAL {$after})
-	")->execute(array());
+	")->execute([]);
 	if (PEAR::isError($res)) {
 		throw new Exception("SQL Error in no-feedback");
 	}
@@ -45,9 +45,9 @@ if ($dbh)
 			UPDATE bugdb
 			SET status = "No Feedback", ts2 = NOW()
 			WHERE id = ?
-		')->execute(array(
+		')->execute([
 			$bug['id'],
-		));
+		]);
 
 		// Send emails
 		mail_bug_updates($bug, $in, $mailfrom, $message);

--- a/www/admin/index.php
+++ b/www/admin/index.php
@@ -10,12 +10,12 @@ if (!$logged_in) {
 	exit;
 }
 
-$actions = array(
+$actions = [
 	'phpinfo' 		=> 'phpinfo()',
 	'list_lists'		=> 'Package mailing lists',
 	'list_responses'	=> 'Quick fix responses',
 	'mysql'			=> 'Database status',
-);
+];
 
 $action  = !empty($_GET['action']) && isset($actions[$_GET['action']]) ? $_GET['action'] : 'list_lists';
 
@@ -29,16 +29,16 @@ if ($action === 'phpinfo') {
 	$phpinfo = ob_get_clean();
 
 	// Attempt to hide certain ENV vars
-	$vars = array(
+	$vars = [
 			getenv('AUTH_TOKEN'),
 			getenv('USER_TOKEN'),
 			getenv('USER_PWD_SALT')
-			);
+			];
 
 	$phpinfo = str_replace($vars, '&lt;hidden&gt;', $phpinfo);
 
 	// Semi stolen from php-web
-	$m = array();
+	$m = [];
 
 	preg_match('!<body.*?>(.*)</body>!ims', $phpinfo, $m);
 
@@ -72,7 +72,7 @@ if ($action === 'phpinfo') {
 
 	echo "<h3>List Responses</h3>\n";
 
-	$rows = array();
+	$rows = [];
 	while ($row = $res->fetchRow(PDO::FETCH_ASSOC)) {
 		// This is ugly but works (tm)
 		$row['message'] = nl2br($row['message']);
@@ -99,7 +99,7 @@ if ($action === 'phpinfo') {
 
 	echo "<h3>Number of rows:</h3>\n";
 
-	$rows = array();
+	$rows = [];
 
 	foreach($row as $key => $value) {
 		$rows[] = [str_replace('cnt_', '', $key), $value];
@@ -107,7 +107,7 @@ if ($action === 'phpinfo') {
 
 	admin_table_static(['Table', 'Rows'], $rows);
 
-	$rows = array();
+	$rows = [];
 	$res = $dbh->query("SHOW TABLE STATUS");
 	echo "<h3>Table status:</h3>\n";
 	while ($row = $res->fetchRow(PDO::FETCH_ASSOC)) {

--- a/www/api.php
+++ b/www/api.php
@@ -27,7 +27,7 @@ if ($type === 'docs' && $action === 'closed' && $interval) {
 	";
 
 	//@todo add error handling
-	$rows = $dbh->prepare($query)->execute(array())->fetchAll(PDO::FETCH_ASSOC);
+	$rows = $dbh->prepare($query)->execute([])->fetchAll(PDO::FETCH_ASSOC);
 	if (!$rows) {
 		echo 'The fail train has arrived.';
 		exit;

--- a/www/bug-pwd-finder.php
+++ b/www/bug-pwd-finder.php
@@ -11,7 +11,7 @@ $numeralCaptcha = new Text_CAPTCHA_Numeral();
 // Obtain common includes
 require_once '../include/prepend.php';
 
-$errors  = array();
+$errors  = [];
 $success = false;
 $bug_id = isset($_REQUEST['id']) ? (int) $_REQUEST['id'] : 0;
 $bug_id = $bug_id ? $bug_id : '';
@@ -42,7 +42,7 @@ if (isset($_POST['captcha']) && $bug_id != '') {
 				'UPDATE bugdb
 				 SET passwd = ?
 				 WHERE id = ?
-				')->execute(array(bugs_get_hash($new_passwd), $bug_id));
+				')->execute([bugs_get_hash($new_passwd), $bug_id]);
 
 				$resp = bugs_mail($row['email'],
 						 "Password for {$siteBig} bug report #{$bug_id}",

--- a/www/bug.php
+++ b/www/bug.php
@@ -32,7 +32,7 @@ if (isset($_REQUEST['id']) && $_REQUEST['id'] == 'preview') {
 }
 
 // Init common variables
-$errors = array();
+$errors = [];
 
 // Set edit mode
 $edit = isset($_REQUEST['edit']) ? (int) $_REQUEST['edit'] : 0;
@@ -86,7 +86,7 @@ if (isset($_POST['subscribe_to_bug']) || isset($_POST['unsubscribe_to_bug'])) {
 			}
 			else // Subscribe
 			{
-				$dbh->prepare('REPLACE INTO bugdb_subscribe SET bug_id = ?, email = ?')->execute(array($bug_id, $email));
+				$dbh->prepare('REPLACE INTO bugdb_subscribe SET bug_id = ?, email = ?')->execute([$bug_id, $email]);
 				$thanks = 7;
 			}
 			redirect("bug.php?id={$bug_id}&thanks={$thanks}");
@@ -169,7 +169,7 @@ $block_user = isset($block_user) ? $block_user : $bug['block_user_comment'];
 $is_private = isset($is_private) ? $is_private : $bug['private'];
 
 // Handle any updates, displaying errors if there were any
-$RESOLVE_REASONS = $FIX_VARIATIONS = $pseudo_pkgs = array();
+$RESOLVE_REASONS = $FIX_VARIATIONS = $pseudo_pkgs = [];
 
 $project = $bug['project'];
 
@@ -332,7 +332,7 @@ if (isset($_POST['ncomment']) && !isset($_POST['preview']) && $edit == 3) {
 				ts2 = NOW(),
 				private = ?
 			WHERE id={$bug_id}
-		")->execute(array(
+		")->execute([
 			$_POST['in']['sdesc'],
 			$_POST['in']['status'],
 			$_POST['in']['package_name'],
@@ -341,7 +341,7 @@ if (isset($_POST['ncomment']) && !isset($_POST['preview']) && $edit == 3) {
 			$_POST['in']['php_os'],
 			$from,
 			$is_private
-		));
+		]);
 
 		// Add changelog entry
 		$changed = bug_diff($bug, $_POST['in']);
@@ -415,7 +415,7 @@ if (isset($_POST['ncomment']) && !isset($_POST['preview']) && $edit == 3) {
 		$errors[] = "You must provide a status";
 	} else {
 		if ($_POST['in']['status'] == 'Not a bug' &&
-			!in_array($bug['status'], array ('Not a bug', 'Closed', 'Duplicate', 'No feedback', 'Wont fix')) &&
+			!in_array($bug['status'], ['Not a bug', 'Closed', 'Duplicate', 'No feedback', 'Wont fix']) &&
 			strlen(trim($ncomment)) == 0
 		) {
 			$errors[] = "You must provide a comment when marking a bug 'Not a bug'";
@@ -506,7 +506,7 @@ if (isset($_POST['ncomment']) && !isset($_POST['preview']) && $edit == 3) {
 				private = ?,
 				ts2 = NOW()
 			WHERE id = {$bug_id}
-		")->execute(array (
+		")->execute([
 			$_POST['in']['sdesc'],
 			$status,
 			$_POST['in']['package_name'],
@@ -517,7 +517,7 @@ if (isset($_POST['ncomment']) && !isset($_POST['preview']) && $edit == 3) {
 			$block_user,
 			$_POST['in']['cve_id'],
 			$is_private
-		));
+		]);
 
 		// Add changelog entry
 		$changed = bug_diff($bug, $_POST['in']);
@@ -1097,13 +1097,13 @@ OUTPUT;
 // Display comments
 $bug_comments = bugs_get_bug_comments($bug_id);
 if ($show_bug_info && is_array($bug_comments) && count($bug_comments) && $bug['status'] !== 'Spam') {
-	$history_tabs = array(
+	$history_tabs = [
 		'type_all'     => 'All',
 		'type_comment' => 'Comments',
 		'type_log'     => 'Changes',
 		'type_svn'     => 'Git/SVN commits',
 		'type_related' => 'Related reports'
-	);
+	];
 
 	if (!isset($_COOKIE['history_tab']) || !isset($history_tabs[$_COOKIE['history_tab']])) {
 		$active_history_tab = 'type_all';

--- a/www/fix.php
+++ b/www/fix.php
@@ -27,7 +27,7 @@ if (!is_array($bug)) {
 }
 
 // If bug exists, continue..
-$RESOLVE_REASONS = $FIX_VARIATIONS = $errors = array();
+$RESOLVE_REASONS = $FIX_VARIATIONS = $errors = [];
 
 $is_trusted_developer = ($user_flags & BUGS_TRUSTED_DEV);
 
@@ -118,13 +118,13 @@ if ($status == $bug['status']) {
 }
 
 // Standard items
-$in = array(
+$in = [
 	'status' => $status,
 	'bug_type' => $bug['bug_type'],
 	'php_version' => $bug['php_version'],
 	'php_os' => $bug['php_os'],
 	'assign' => $bug['assign'],
-);
+];
 
 // Assign automatically when closed
 if ($status == 'Closed' && $in['assign'] == '') {
@@ -139,11 +139,11 @@ $dbh->prepare("
 		assign = ?,
 		ts2 = NOW()
 	WHERE id = ?
-")->execute(array (
+")->execute([
 	$status,
 	$in['assign'],
 	$bug_id,
-));
+]);
 
 // Add changelog entry
 if (!PEAR::isError($res)) {

--- a/www/gh-pull-add.php
+++ b/www/gh-pull-add.php
@@ -54,7 +54,7 @@ require_once "{$ROOT_DIR}/include/classes/bug_ghpulltracker.php";
 $pullinfo = new Bug_Pulltracker;
 
 if (isset($_POST['addpull'])) {
-	$errors = array();
+	$errors = [];
 	if (empty($_POST['repository'])) {
 		$errors[] = 'No repository selected';
 	}
@@ -97,7 +97,7 @@ if (isset($_POST['addpull'])) {
 		$newpr = $pullinfo->attach($bug_id, $_POST['repository'], $_POST['pull_id'], $email);
 		PEAR::popErrorHandling();
 		if (PEAR::isError($newpr)) {
-			$errors = array($newpr->getMessage(), 'Could not attach pull request to Bug #' . $bug_id);
+			$errors = [$newpr->getMessage(), 'Could not attach pull request to Bug #' . $bug_id];
 		}
 	}
 
@@ -123,7 +123,7 @@ TXT;
 	mail_bug_updates($buginfo, $buginfo, $auth_user->email, $text, 4, $bug_id);
  */
 	$pulls = $pullinfo->listPulls($bug_id);
-	$errors = array();
+	$errors = [];
 	include "{$ROOT_DIR}/templates/addghpull.php";
 	exit;
 }

--- a/www/index.php
+++ b/www/index.php
@@ -95,7 +95,7 @@ to a random open bug.</p>
 <?php
 	$base_default = "{$site_method}://{$site_url}/search.php?limit=30&amp;order_by=id&amp;direction=DESC&amp;cmd=display&amp;status=Open";
 
-	$searches = array(
+	$searches = [
 		'Most recent open bugs (all)' => '&bug_type=All',
 		'Most recent open bugs (all) with patch or pull request' => '&bug_type=All&patch=Y&pull=Y',
 		'Most recent open bugs (PHP 5.6)' => '&bug_type=All&phpver=5.6',
@@ -105,7 +105,7 @@ to a random open bug.</p>
 		'Most recent open bugs (PHP 7.3)' => '&bug_type=All&phpver=7.3',
 		'Open Documentation bugs' => '&bug_type=Documentation+Problem',
 		'Open Documentation bugs (with patches)' => '&bug_type=Documentation+Problem&patch=Y'
-	);
+	];
 
 	if (!empty($_SESSION["user"])) {
 		$searches['Your assigned open bugs'] = '&assign='.urlencode($_SESSION['user']);

--- a/www/js/userlisting.php
+++ b/www/js/userlisting.php
@@ -5,8 +5,8 @@ ini_set('zlib.output_compression', 1);
 
 function getAllUsers()
 {
-	$opts = array('ignore_errors' => true);
-	$ctx = stream_context_create(array('http' => $opts));
+	$opts = ['ignore_errors' => true];
+	$ctx = stream_context_create(['http' => $opts]);
 	$token = getenv('USER_TOKEN');
 
 	$retval = @file_get_contents('https://master.php.net/fetch/allusers.php?&token=' . rawurlencode($token), false, $ctx);
@@ -47,18 +47,18 @@ if (isset($_SERVER['HTTP_IF_MODIFIED_SINCE']) && $_SERVER['HTTP_IF_MODIFIED_SINC
 	header("Expires: {$expires}");
 }
 
-$lookup = $user = array();
+$lookup = $user = [];
 
 if ($json) {
 	foreach ($json as $row) {
 		$lookup[] = $row['name'];
 		$lookup[] = $row["username"];
 
-		$data = array(
+		$data = [
 			'email'		=> md5($row['username'] . '@php.net'),
 			'name'		=> $row['name'],
 			'username'	=> $row['username'],
-		);
+		];
 		$user[$row["username"]] = $data;
 		$user[$row["name"]]     = $data;
 	}

--- a/www/lstats.php
+++ b/www/lstats.php
@@ -27,7 +27,7 @@ function get_status_count ($status, $category = '')
 	}
 	$query.= "AND bug_type NOT IN({$excluded})";
 
-	$res = $dbh->prepare($query)->execute(array());
+	$res = $dbh->prepare($query)->execute([]);
 	$row = $res->fetchRow(PDO::FETCH_NUM);
 
 	return $row[0];
@@ -47,7 +47,7 @@ if (isset($_GET['per_category']))
 	$project = !empty($_GET['project']) ? $_GET['project'] : false;
 	$pseudo_pkgs = get_pseudo_packages($project);
 
-	$totals = array();
+	$totals = [];
 	foreach ($pseudo_pkgs as $category => $data) {
 		$count = get_status_count ("status NOT IN('to be documented', 'closed', 'not a bug', 'duplicate', 'wont fix', 'no feedback')", $category);
 		if ($count > 0) {
@@ -62,7 +62,7 @@ if (isset($_GET['per_category']))
 } else {
 
 	foreach ($tla as $status => $short) {
-		if (!in_array($status, array('Duplicate'))) {
+		if (!in_array($status, ['Duplicate'])) {
 			$count = get_status_count ($status);
 			status_print($status, $count, 30);
 		}

--- a/www/patch-add.php
+++ b/www/patch-add.php
@@ -58,7 +58,7 @@ $patch_name_url = urlencode($patch_name);
 
 if (isset($_POST['addpatch'])) {
 	if (!isset($_POST['obsoleted'])) {
-		$_POST['obsoleted'] = array();
+		$_POST['obsoleted'] = [];
 	}
 
 	// Check that patch name is given (required always)
@@ -71,7 +71,7 @@ if (isset($_POST['addpatch'])) {
 
 	if (!$logged_in) {
 		try {
-			$errors = array();
+			$errors = [];
 
 			$email = isset($_POST['email']) ? $_POST['email'] : '';
 
@@ -119,10 +119,10 @@ if (isset($_POST['addpatch'])) {
 	PEAR::popErrorHandling();
 	if (PEAR::isError($e)) {
 		$patches = $patchinfo->listPatches($bug_id);
-		$errors = array($e->getMessage(),
+		$errors = [$e->getMessage(),
 			'Could not attach patch "' .
 			htmlspecialchars($patch_name) .
-			'" to Bug #' . $bug_id);
+			'" to Bug #' . $bug_id];
 		include "{$ROOT_DIR}/templates/addpatch.php";
 		exit;
 	}
@@ -144,7 +144,7 @@ TXT;
 	mail_bug_updates($buginfo, $buginfo, $auth_user->email, $text, 4, $bug_id);
 
 	$patches = $patchinfo->listPatches($bug_id);
-	$errors = array();
+	$errors = [];
 	include "{$ROOT_DIR}/templates/patchadded.php";
 	exit;
 }

--- a/www/report.php
+++ b/www/report.php
@@ -7,7 +7,7 @@ require_once '../include/prepend.php';
 session_start();
 
 // Init variables
-$errors = array();
+$errors = [];
 $ok_to_submit_report = false;
 
 $project = !empty($_GET['project']) ? $_GET['project'] : false;
@@ -118,7 +118,7 @@ if (isset($_POST['in'])) {
 						WHERE bug = ?
 						ORDER BY id DESC
 						LIMIT 1
-					")->execute(array($row['id']))->fetchOne();
+					")->execute([$row['id']])->fetchOne();
 
 					$summary = $row['ldesc'];
 					if (strlen($summary) > 256) {
@@ -205,7 +205,7 @@ OUTPUT;
 					private,
 					visitor_ip
 				) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, "Open", NOW(), ?, INET6_ATON(?))
-			')->execute(array(
+			')->execute([
 					$package_name,
 					$_POST['in']['bug_type'],
 					$_POST['in']['email'],
@@ -217,7 +217,7 @@ OUTPUT;
 					$_POST['in']['reporter_name'],
 					$_POST['in']['private'],
 					$_SERVER['REMOTE_ADDR']
-				)
+				]
 			);
 
 			$cid = $dbh->lastInsertId();
@@ -227,7 +227,7 @@ OUTPUT;
 				require_once "{$ROOT_DIR}/include/classes/bug_patchtracker.php";
 				$tracker = new Bug_Patchtracker;
 				PEAR::staticPushErrorHandling(PEAR_ERROR_RETURN);
-				$patchrevision = $tracker->attach($cid, 'patchfile', $_POST['in']['patchname'], $_POST['in']['handle'], array());
+				$patchrevision = $tracker->attach($cid, 'patchfile', $_POST['in']['patchname'], $_POST['in']['handle'], []);
 				PEAR::staticPopErrorHandling();
 				if (PEAR::isError($patchrevision)) {
 					$redirectToPatchAdd = true;
@@ -337,7 +337,7 @@ if (!is_string($package)) {
 
 if (!isset($_POST['in'])) {
 
-	$_POST['in'] = array(
+	$_POST['in'] = [
 			 'package_name' => isset($_GET['package_name']) ? clean($_GET['package_name']) : '',
 			 'bug_type' => isset($_GET['bug_type']) ? clean($_GET['bug_type']) : '',
 			 'email' => '',
@@ -349,7 +349,7 @@ if (!isset($_POST['in'])) {
 			 'php_version' => '',
 			 'php_os' => '',
 			 'passwd' => '',
-	);
+	];
 
 
 	response_header('Report - New', $packageAffectedScript);

--- a/www/rpc.php
+++ b/www/rpc.php
@@ -10,7 +10,7 @@ session_start();
 $bug_id = (isset($_REQUEST['id']) ? (int) $_REQUEST['id'] : 0);
 
 if (!$bug_id) {
-	echo json_encode(array('result' => array('error' => 'Missing bug id')));
+	echo json_encode(['result' => ['error' => 'Missing bug id']]);
 	exit;
 }
 
@@ -23,7 +23,7 @@ if (isset($_POST['MAGIC_COOKIE'])) {
 	$auth_user->handle = $user;
 	$auth_user->password = $pwd;
 } else {
-	echo json_encode(array('result' => array('error' => 'Missing credentials')));
+	echo json_encode(['result' => ['error' => 'Missing credentials']]);
 	exit;
 }
 
@@ -32,7 +32,7 @@ bugs_authenticate($user, $pwd, $logged_in, $user_flags);
 $is_trusted_developer = ($user_flags & BUGS_TRUSTED_DEV);
 
 if (empty($auth_user->handle)) {
-	echo json_encode(array('result' => array('error' => 'Invalid user or password')));
+	echo json_encode(['result' => ['error' => 'Invalid user or password']]);
 	exit;
 }
 
@@ -40,12 +40,12 @@ if (empty($auth_user->handle)) {
 $bug = bugs_get_bug($bug_id);
 
 if (!is_array($bug)) {
-	echo json_encode(array('result' => array('error' => 'No such bug')));
+	echo json_encode(['result' => ['error' => 'No such bug']]);
 	exit;
 }
 
 if (!bugs_has_access($bug_id, $bug, $pwd, $user_flags)) {
-	echo json_encode(array('result' => array('error' => 'No access to bug')));
+	echo json_encode(['result' => ['error' => 'No access to bug']]);
 	exit;
 }
 
@@ -82,15 +82,15 @@ if (!empty($_POST['ncomment']) && !empty($_POST['user'])) {
 			mail_bug_updates($bug, $in, $from, $ncomment, 1, $bug_id);
 		}
 
-		echo json_encode(array('result' => array('status' => $bug)));
+		echo json_encode(['result' => ['status' => $bug]]);
 		exit;
 	} catch (Exception $e) {
-		echo json_encode(array('result' => array('error' => $e->getMessage())));
+		echo json_encode(['result' => ['error' => $e->getMessage()]]);
 		exit;
 	}
 } else if (!empty($_POST['getbug'])) {
-	echo json_encode(array('result' => array('status' => $bug)));
+	echo json_encode(['result' => ['status' => $bug]]);
 	exit;
 }
 
-echo json_encode(array('result' => array('error' => 'Nothing to do')));
+echo json_encode(['result' => ['error' => 'Nothing to do']]);

--- a/www/stats.php
+++ b/www/stats.php
@@ -10,7 +10,7 @@ bugs_authenticate($user, $pw, $logged_in, $user_flags);
 
 response_header('Bugs Stats');
 
-$titles = array(
+$titles = [
 	'Closed'	=> 'Closed',
 	'Open'		=> 'Open',
 	'Critical'	=> 'Crit',
@@ -23,17 +23,17 @@ $titles = array(
 	'Not a bug'	=> 'Not&nbsp;a&nbsp;bug',
 	'Duplicate'	=> 'Dupe',
 	'Wont fix'	=> 'Wont&nbsp;Fix',
-);
+];
 
 $rev = isset($_GET['rev']) ? $_GET['rev'] : 1;
 $sort_by = isset($_GET['sort_by']) ? $_GET['sort_by'] : 'Open';
 $total = 0;
-$row = array();
-$pkg = array();
-$pkg_tmp = array();
-$pkg_total = array();
-$pkg_names = array();
-$all = array();
+$row = [];
+$pkg = [];
+$pkg_tmp = [];
+$pkg_total = [];
+$pkg_names = [];
+$all = [];
 $pseudo	= true;
 $pseudo_pkgs = get_pseudo_packages($site);
 

--- a/www/vote.php
+++ b/www/vote.php
@@ -20,7 +20,7 @@ $reproduced = (int) $_POST['reproduced'];
 $samever = isset($_POST['samever']) ? (int) $_POST['samever'] : 0;
 $sameos = isset($_POST['sameos']) ? (int) $_POST['sameos'] : 0;
 
-if (!$dbh->prepare("SELECT id FROM bugdb WHERE id= ? LIMIT 1")->execute(array($id))->fetchOne()) {
+if (!$dbh->prepare("SELECT id FROM bugdb WHERE id= ? LIMIT 1")->execute([$id])->fetchOne()) {
 	session_start();
 
 	// Authenticate
@@ -62,7 +62,7 @@ $ip = ip2long(get_real_ip());
 
 // Check whether the user has already voted on this bug.
 $bug_check = $dbh->prepare("SELECT bug, ip FROM bugdb_votes WHERE bug = ? AND ip = ? LIMIT 1")
-	->execute(array($id, $ip))
+	->execute([$id, $ip])
 	->fetchRow();
 
 if (empty($bug_check)) {
@@ -85,7 +85,7 @@ if (empty($bug_check)) {
 	$dbh->prepare("UPDATE bugdb_votes
 		SET score = ?, reproduced = ? , tried = ?, sameos = ?, samever = ?
 		WHERE bug = ? AND ip = ?")
-		->execute(array(
+		->execute([
 			$score,
 			($reproduced == 1 ? "1" : "0"),
 			($reproduced != 2 ? "1" : "0"),
@@ -93,7 +93,7 @@ if (empty($bug_check)) {
 			($reproduced ? "$samever" : null),
 			$id,
 			$ip
-		));
+		]);
 
 	// Let the user know they have already voted and the existing vote will be
 	// updated.


### PR DESCRIPTION
Since site is using PHP 5.4+ already, the longer `array()` syntax can be refactored to shorter `[]`. Also code is already using short array syntax on some places.