### PR TITLE
Remove redundant script type="text/javascript" attributes

### DIFF
--- a/templates/addghpull.php
+++ b/templates/addghpull.php
@@ -1,9 +1,9 @@
 <?php
 response_header('Add Pull Request :: ' . clean($package_name));
 ?>
-<script type='text/javascript' src='https://ajax.googleapis.com/ajax/libs/jquery/1.4.2/jquery.min.js'></script>
-<script type="text/javascript" src="js/Markdown.Converter.js"></script>
-<script type="text/javascript" src="js/Markdown.Sanitizer.js"></script>
+<script src='https://ajax.googleapis.com/ajax/libs/jquery/1.4.2/jquery.min.js'></script>
+<script src="js/Markdown.Converter.js"></script>
+<script src="js/Markdown.Sanitizer.js"></script>
 <h2>Add a Pull Request to <a href="bug.php?id=<?php echo $bug_id; ?>">Bug #<?php echo $bug_id; ?></a></h2>
 <ul>
  <li>One problem per pull request, please</li>

--- a/www/bug.php
+++ b/www/bug.php
@@ -1149,10 +1149,10 @@ if ($bug_id == 'PREVIEW') {
 <?php }
 
 $bug_JS = <<< bug_JS
-<script type='text/javascript' src='js/util.js'></script>
-<script type='text/javascript' src='https://ajax.googleapis.com/ajax/libs/jquery/1.4.2/jquery.min.js'></script>
-<script type="text/javascript" src="js/jquery.cookie.js"></script>
-<script type="text/javascript">
+<script src='js/util.js'></script>
+<script src='https://ajax.googleapis.com/ajax/libs/jquery/1.4.2/jquery.min.js'></script>
+<script src="js/jquery.cookie.js"></script>
+<script>
 function do_comment(nd)
 {
 	$('#comment_filter > .control.active').removeClass("active");
@@ -1178,9 +1178,9 @@ bug_JS;
 
 if ($edit == 1) {
 	$bug_JS .= '
-<script type="text/javascript" src="js/jquery.autocomplete-min.js"></script>
-<script type="text/javascript" src="js/userlisting.php"></script> 	
-<script type="text/javascript" src="js/search.js"></script>
+<script src="js/jquery.autocomplete-min.js"></script>
+<script src="js/userlisting.php"></script>
+<script src="js/search.js"></script>
 	';
 
 }

--- a/www/index.php
+++ b/www/index.php
@@ -28,7 +28,7 @@ response_header('Bugs');
 
 ?>
 
-<script type="text/javascript">
+<script>
 var bugid = window.location.hash.substr(1) * 1;
 if (bugid > 0) {
 	var loc = window.location;

--- a/www/report.php
+++ b/www/report.php
@@ -28,7 +28,7 @@ if (!$logged_in) {
 }
 
 $packageAffectedScript = <<<SCRIPT
-	<script type="text/javascript" src="$site_method://$site_url$basedir/js/package-affected.js"></script>
+	<script src="$site_method://$site_url$basedir/js/package-affected.js"></script>
 SCRIPT;
 
 // Handle input


### PR DESCRIPTION
Omitted type means that script is JavaScript [1] and for HTML 5 browsers can be removed today.

[1] https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script