### PR TITLE
Fix #76961: vote throws a Server Error over ipv6

### DIFF
--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -97,7 +97,7 @@ CREATE TABLE bugdb_subscribe (
 CREATE TABLE bugdb_votes (
   bug int(8) NOT NULL default '0',
   ts timestamp NOT NULL default CURRENT_TIMESTAMP on update CURRENT_TIMESTAMP,
-  ip int(10) unsigned NOT NULL default '0',
+  ip varbinary(16) NOT NULL,
   score int(3) NOT NULL default '0',
   reproduced int(1) NOT NULL default '0',
   tried int(1) NOT NULL default '0',


### PR DESCRIPTION
This patch fixes a bug when user with IPv6 is voting on a bug. It syncs the functionality with the rest of the ip column types in the database.

Before applying this patch, the database schema needs to be updated and current IPs should ideally be converted from integers to numeric values returned by the INET6_ATON() MySQL function.

Bug: [https://bugs.php.net/bug.php?id=76961](https://bugs.php.net/bug.php?id=76961)