### PR TITLE
Refactor get_pseudo_packages() to repository class

### DIFF
--- a/include/query.php
+++ b/include/query.php
@@ -1,5 +1,7 @@
 <?php
 
+use App\Repository\PackageRepository;
+
 $errors = [];
 $warnings = [];
 $order_options = [
@@ -20,7 +22,8 @@ $order_options = [
 ];
 
 // Fetch pseudo packages
-$pseudo_pkgs = get_pseudo_packages(false);
+$packageRepository = new PackageRepository($dbh);
+$pseudo_pkgs = $packageRepository->findAll();
 
 // Setup input variables..
 $boolean_search = isset($_GET['boolean']) ? (int) $_GET['boolean'] : 0;

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -30,9 +30,4 @@ class Database extends \PDO
     {
         return substr($this->quote($text), 1, -1);
     }
-
-    public function queryAll($query, $types = null, $fetchmode = null, $rekey = false, $force_array = false, $group = false)
-    {
-        return $this->query($query)->fetchAll();
-    }
 }

--- a/src/Repository/PackageRepository.php
+++ b/src/Repository/PackageRepository.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace App\Repository;
+
+use App\Database\Database;
+
+/**
+ * Repository class for retrieving data from the bugdb_pseudo_packages database
+ * table.
+ */
+class PackageRepository
+{
+    /**
+     * Database handler.
+     * @var Database
+     */
+    private $dbh;
+
+    /**
+     * Project types.
+     */
+    public const PROJECTS = [
+        'PHP'  => 'php',
+        'PECL' => 'pecl',
+    ];
+
+    /**
+     * Class constructor.
+     */
+    public function __construct(Database $dbh)
+    {
+        $this->dbh = $dbh;
+    }
+
+    /**
+     * Find all packages by project type.
+     */
+    public function findAll(string $project = ''): array
+    {
+        $sql = 'SELECT * FROM bugdb_pseudo_packages';
+        $arguments = [];
+
+        $project = strtolower($project);
+        if (in_array($project, self::PROJECTS)) {
+            $sql .= " WHERE project IN ('', ?)";
+            $arguments[] = $project;
+        }
+
+        $sql .= ' ORDER BY parent, disabled, id';
+
+        $data = $this->dbh->prepare($sql)->execute($arguments)->fetchAll();
+
+        return $this->getNested($data);
+    }
+
+    /**
+     * Find all enabled packages by project type.
+     */
+    public function findEnabled(string $project = ''): array
+    {
+        $sql = 'SELECT * FROM bugdb_pseudo_packages WHERE disabled = 0';
+        $arguments = [];
+
+        $project = strtolower($project);
+        if (in_array($project, self::PROJECTS)) {
+            $sql .= " AND project IN ('', ?)";
+            $arguments[] = $project;
+        }
+
+        $sql .= ' ORDER BY parent, id';
+
+        $data = $this->dbh->prepare($sql)->execute($arguments)->fetchAll();
+
+        return $this->getNested($data);
+    }
+
+    /**
+     * Convert flat array to nested structure.
+     */
+    private function getNested(array $data): array
+    {
+        $packages = [];
+        $nodes = [];
+        $tree = [];
+
+        foreach ($data as &$node) {
+            $node['children'] = [];
+            $id = $node['id'];
+            $parentId = $node['parent'];
+            $nodes[$id] =& $node;
+
+            if (array_key_exists($parentId, $nodes)) {
+                $nodes[$parentId]['children'][] =& $node;
+            } else {
+                $tree[] =& $node;
+            }
+        }
+
+        foreach ($tree as $data) {
+            if (isset($data['children'])) {
+                $packages[$data['name']] = [$data['long_name'], $data['disabled'], []];
+                $children = &$packages[$data['name']][2];
+                $longNames = [];
+
+                foreach ($data['children'] as $k => $v) {
+                    $longNames[$k] = strtolower($v['long_name']);
+                }
+
+                array_multisort($longNames, SORT_ASC, SORT_STRING, $data['children']);
+
+                foreach ($data['children'] as $child) {
+                    $packages[$child['name']] = ["{$child['long_name']}", $child['disabled'], null];
+                    $children[] = $child['name'];
+                }
+            } elseif (!isset($packages[$data['name']])) {
+                $packages[$data['name']] = [$data['long_name'], $data['disabled'], null];
+            }
+        }
+
+        return $packages;
+    }
+}

--- a/www/bug.php
+++ b/www/bug.php
@@ -2,6 +2,7 @@
 /* User interface for viewing and editing bug details */
 
 use App\Repository\ObsoletePatchRepository;
+use App\Repository\PackageRepository;
 use App\Repository\PatchRepository;
 use App\Utils\Captcha;
 use App\Repository\PullRequestRepository;
@@ -182,7 +183,8 @@ $project = $bug['project'];
 
 // Only fetch stuff when it's really needed
 if ($edit && $edit < 3) {
-	$pseudo_pkgs = get_pseudo_packages(false, false); // false == no read-only packages included
+	$packageRepository = new PackageRepository($dbh);
+	$pseudo_pkgs = $packageRepository->findEnabled();
 }
 
 // Fetch RESOLVE_REASONS array

--- a/www/lstats.php
+++ b/www/lstats.php
@@ -1,5 +1,7 @@
 <?php
 
+use App\Repository\PackageRepository;
+
 require '../include/prepend.php';
 
 function status_print ($status, $num, $width, $align = STR_PAD_LEFT)
@@ -44,8 +46,8 @@ if (!$phpver || ($phpver !== 5 && $phpver !== 7)) {
 
 if (isset($_GET['per_category']))
 {
-	$project = !empty($_GET['project']) ? $_GET['project'] : false;
-	$pseudo_pkgs = get_pseudo_packages($project);
+	$packageRepository = new PackageRepository($dbh);
+	$pseudo_pkgs = $packageRepository->findAll($_GET['project'] ?? '');
 
 	$totals = [];
 	foreach ($pseudo_pkgs as $category => $data) {

--- a/www/patch-display.php
+++ b/www/patch-display.php
@@ -54,8 +54,6 @@ if (!bugs_has_access($bug_id, $buginfo, $pw, $user_flags)) {
 	exit;
 }
 
-$pseudo_pkgs = get_pseudo_packages(false);
-
 if (isset($patch_name) && isset($revision)) {
 	if ($revision == 'latest') {
 		$revisions = $patchRepository->findRevisions($buginfo['id'], $patch_name);

--- a/www/report.php
+++ b/www/report.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Repository\PackageRepository;
 use App\Utils\Captcha;
 use App\Utils\PatchTracker;
 use App\Utils\Uploader;
@@ -14,8 +15,8 @@ session_start();
 $errors = [];
 $ok_to_submit_report = false;
 
-$project = !empty($_GET['project']) ? $_GET['project'] : false;
-$pseudo_pkgs = get_pseudo_packages($project, false); // false == no read-only packages included
+$packageRepository = new PackageRepository($dbh);
+$pseudo_pkgs = $packageRepository->findEnabled($_GET['project'] ?? '');
 
 // Authenticate
 bugs_authenticate($user, $pw, $logged_in, $user_flags);
@@ -277,10 +278,8 @@ REPORT;
 				$type = 'unknown';
 			}
 
-			$project = !empty($_GET['project']) ? $_GET['project'] : false;
-
 			// provide shortcut URLS for "quick bug fixes"
-			list($RESOLVE_REASONS, $FIX_VARIATIONS) = get_resolve_reasons($project);
+			list($RESOLVE_REASONS, $FIX_VARIATIONS) = get_resolve_reasons($_GET['project'] ?? false);
 
 			$dev_extra = '';
 			$maxkeysize = 0;

--- a/www/search.php
+++ b/www/search.php
@@ -1,5 +1,7 @@
 <?php
 
+use App\Repository\PackageRepository;
+
 // Start session
 session_start();
 
@@ -256,7 +258,14 @@ display_bug_error($warnings, 'warnings', 'WARNING:');
   <td style="white-space: nowrap">
    <label for="bug_type">Return bugs with <b>project</b></label>
   </td>
-  <td><select id="project" name="project"><?php show_project_options($project, true);?></select></td>
+  <td><select id="project" name="project">
+      <option value="All"<?php if ($project === ''): ?> selected="selected"<?php endif;?>>All</option>
+
+      <?php foreach (PackageRepository::PROJECTS as $key => $value): ?>
+        <option value="<?= htmlspecialchars($key, ENT_QUOTES); ?>" <?php if ($project === strtolower($key)): ?> selected="selected"<?php endif; ?>><?= htmlspecialchars($key, ENT_QUOTES); ?></option>
+      <?php endforeach; ?>
+    </select>
+  </td>
 </tr>
 </table>
 

--- a/www/stats.php
+++ b/www/stats.php
@@ -35,7 +35,6 @@ $pkg_total = [];
 $pkg_names = [];
 $all = [];
 $pseudo	= true;
-$pseudo_pkgs = get_pseudo_packages($site);
 
 if (!array_key_exists($sort_by, $titles)) {
 	$sort_by = 'Open';


### PR DESCRIPTION
Changes:
- get_pseudo_packages() function is moved to its own repository class.
- Database::queryAll() removed since it is not used and the method
  arguments don't match the number of used arguments anymore
- Project types configuration is moved to repository class for now.
- Some unused items removed
- Some template changes and show_project_options() helper function
  integrated in the view layer directly since it is used in a simplified
  way.