### PR TITLE
Move fetching bug comments to separate class

### DIFF
--- a/include/functions.php
+++ b/include/functions.php
@@ -1483,26 +1483,6 @@ function bugs_get_bug($bug_id)
 }
 
 /**
- * Fetch bug comments
- *
- * @return mixed array of bug comments or object with error info
- */
-function bugs_get_bug_comments($bug_id)
-{
-	global $dbh;
-
-	$query = "
-		SELECT c.id, c.email, c.comment, c.comment_type,
-			UNIX_TIMESTAMP(c.ts) AS added,
-			c.reporter_name AS comment_name
-		FROM bugdb_comments c
-		WHERE c.bug = ?
-		GROUP BY c.id ORDER BY c.ts
-	";
-	return $dbh->prepare($query)->execute([$bug_id])->fetchAll();
-}
-
-/**
  * Add bug comment
  */
 function bugs_add_comment($bug_id, $from, $from_name, $comment, $type = 'comment')

--- a/src/Repository/CommentRepository.php
+++ b/src/Repository/CommentRepository.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Repository;
+
+/**
+ * Repository class for fetching data from the bugdb_comments table.
+ */
+class CommentRepository
+{
+    /**
+     * Database handler.
+     * @var \PDO
+     */
+    private $dbh;
+
+    /**
+     * Class constructor.
+     */
+    public function __construct(\PDO $dbh)
+    {
+        $this->dbh = $dbh;
+    }
+
+    /**
+     * Fetch bug comments
+     */
+    public function findByBugId(int $id): array
+    {
+        $sql = 'SELECT c.id, c.email, c.comment, c.comment_type,
+                    UNIX_TIMESTAMP(c.ts) AS added,
+                    c.reporter_name AS comment_name
+                FROM bugdb_comments c
+                WHERE c.bug = ?
+                GROUP BY c.id ORDER BY c.ts
+        ';
+
+        $statement = $this->dbh->prepare($sql);
+        $statement->execute([$id]);
+
+        return $statement->fetchAll();
+    }
+}

--- a/www/bug.php
+++ b/www/bug.php
@@ -1,6 +1,7 @@
 <?php
 /* User interface for viewing and editing bug details */
 
+use App\Repository\CommentRepository;
 use App\Repository\ObsoletePatchRepository;
 use App\Repository\PackageRepository;
 use App\Repository\PatchRepository;
@@ -1100,7 +1101,9 @@ OUTPUT;
 }
 
 // Display comments
-$bug_comments = bugs_get_bug_comments($bug_id);
+$commentRepository = new CommentRepository($dbh);
+$bug_comments = is_int($bug_id) ? $commentRepository->findByBugId($bug_id) : [];
+
 if ($show_bug_info && is_array($bug_comments) && count($bug_comments) && $bug['status'] !== 'Spam') {
 	$history_tabs = [
 		'type_all'     => 'All',

--- a/www/rss/bug.php
+++ b/www/rss/bug.php
@@ -1,5 +1,7 @@
 <?php
 
+use App\Repository\CommentRepository;
+
 /* Generates an RSS/RDF feed for a particular bug specified as the "id"
  * parameter.  optionally, if "format" is "xml", generates data in a
  * non-standard xml format.
@@ -25,7 +27,8 @@ if ($bug['private'] == 'Y') {
 	die('Access restricted');
 }
 
-$comments = bugs_get_bug_comments($bug_id);
+$commentRepository = new CommentRepository($dbh);
+$comments = $commentRepository->findByBugId($bug_id);
 
 if ($format == 'xml') {
 	header('Content-type: text/xml; charset=utf-8');


### PR DESCRIPTION
This is work in progress to move more parts of procedural coding to OOP...

Changes:
- This moves fetching bug comments to a dedicated repository class

TODO:
- [x] `bugs_get_bug_comments()` moved to repository class
- [x] Fix string 'preview' for $_REQUEST['bug_id'] in bug.php file and its errors.
- [x] ~~get_old_comments()~~ - moving this into separate pull request after this one.
