### PR TITLE
Refactor get_resolve_reasons() to repository class

### DIFF
--- a/include/functions.php
+++ b/include/functions.php
@@ -1422,38 +1422,6 @@ function unsubscribe($bug_id, $hash)
 	return true;
 }
 
-
-/**
- * Fetch bug resolves
- *
- * @return array array of resolves
- */
-function get_resolve_reasons($project = false)
-{
-	global $dbh;
-
-	$where = '';
-
-	if ($project !== false) {
-		$project = $dbh->quote($project);
-		$where.= "WHERE (project = {$project} OR project = '')";
-	}
-
-	$resolves = $variations = [];
-	$res = $dbh->prepare("SELECT * FROM bugdb_resolves $where")->execute([]);
-	if (!$res) {
-		throw new Exception("SQL Error in get_resolve_reasons");
-	}
-	while ($row = $res->fetch()) {
-		if (!empty($row['package_name'])) {
-			$variations[$row['name']][$row['package_name']] = $row['message'];
-		} else {
-			$resolves[$row['name']] = $row;
-		}
-	}
-	return [$resolves, $variations];
-}
-
 /**
  * Fetch bug data
  *

--- a/scripts/cron/no-feedback
+++ b/scripts/cron/no-feedback
@@ -3,6 +3,8 @@
 
 # this script closes bugs due to lack of feedback.
 
+use App\Repository\ReasonRepository;
+
 require __DIR__.'/../../include/prepend.php';
 
 # date interval to close after
@@ -14,7 +16,9 @@ $in = ['status' => 'No Feedback'];
 # Update relevant reports
 if ($dbh)
 {
-	list($RESOLVE_REASONS, $FIX_VARIATIONS) = get_resolve_reasons($site);
+	$reasonRepository = new ReasonRepository($dbh);
+
+	list($RESOLVE_REASONS, $FIX_VARIATIONS) = $reasonRepository->findByProject($site);
 
 	$res = $dbh->prepare("
 		SELECT id, package_name, bug_type, email, passwd, sdesc, ldesc, php_version,

--- a/src/Repository/ReasonRepository.php
+++ b/src/Repository/ReasonRepository.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Repository;
+
+/**
+ * Repository class for fetching data from the bugdb_resolves database table.
+ */
+class ReasonRepository
+{
+    /**
+     * Database handle.
+     * @var \PDO
+     */
+    private $dbh;
+
+    /**
+     * Class constructor
+     */
+    public function __construct(\PDO $dbh)
+    {
+        $this->dbh = $dbh;
+    }
+
+    /**
+     * Fetch bug resolves.
+     */
+    public function findByProject(string $project = ''): array
+    {
+        $sql = 'SELECT * FROM bugdb_resolves';
+        $arguments = [];
+
+        if ($project !== '') {
+            $sql = " WHERE (project = ? OR project = '')";
+            $arguments[] = $project;
+        }
+
+        $resolves = $variations = [];
+        $statement = $this->dbh->prepare($sql);
+        $exec = $statement->execute($arguments);
+
+        if (!$exec) {
+            throw new \Exception('Error when fetching resolve reasons.');
+        }
+
+        while ($row = $statement->fetch()) {
+            if (!empty($row['package_name'])) {
+                $variations[$row['name']][$row['package_name']] = $row['message'];
+            } else {
+                $resolves[$row['name']] = $row;
+            }
+        }
+
+        return [$resolves, $variations];
+    }
+}

--- a/www/bug.php
+++ b/www/bug.php
@@ -7,6 +7,7 @@ use App\Repository\PackageRepository;
 use App\Repository\PatchRepository;
 use App\Utils\Captcha;
 use App\Repository\PullRequestRepository;
+use App\Repository\ReasonRepository;
 
 // Obtain common includes
 require_once '../include/prepend.php';
@@ -190,7 +191,8 @@ if ($edit && $edit < 3) {
 
 // Fetch RESOLVE_REASONS array
 if ($edit === 1) {
-	list($RESOLVE_REASONS, $FIX_VARIATIONS) = get_resolve_reasons($project);
+	$reasonRepository = new ReasonRepository($dbh);
+	list($RESOLVE_REASONS, $FIX_VARIATIONS) = $reasonRepository->findByProject($project);
 }
 
 if (isset($_POST['ncomment']) && !isset($_POST['preview']) && $edit == 3) {

--- a/www/fix.php
+++ b/www/fix.php
@@ -1,5 +1,7 @@
 <?php
 
+use App\Repository\ReasonRepository;
+
 session_start();
 
 /* Admin interface for closing bug reports via direct link */
@@ -37,7 +39,8 @@ if ($logged_in != 'developer') {
 
 $project = !empty($_GET['project']) ? $_GET['project'] : false;
 
-list($RESOLVE_REASONS, $FIX_VARIATIONS) = get_resolve_reasons($site);
+$reasonRepository = new ReasonRepository($dbh);
+list($RESOLVE_REASONS, $FIX_VARIATIONS) = $reasonRepository->findByProject($site);
 
 // Handle reason / comments
 $reason = filter_var($_REQUEST['r'], FILTER_SANITIZE_STRING);

--- a/www/quick-fix-desc.php
+++ b/www/quick-fix-desc.php
@@ -1,11 +1,14 @@
 <?php
 
+use App\Repository\ReasonRepository;
+
 session_start();
 
 // Obtain common includes
 require_once '../include/prepend.php';
 
-list($RESOLVE_REASONS, $FIX_VARIATIONS) = get_resolve_reasons($site);
+$reasonRepository = new ReasonRepository($dbh);
+list($RESOLVE_REASONS, $FIX_VARIATIONS) = $reasonRepository->findByProject($site);
 
 // Authenticate
 bugs_authenticate($user, $pw, $logged_in, $user_flags);

--- a/www/report.php
+++ b/www/report.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Repository\PackageRepository;
+use App\Repository\ReasonRepository;
 use App\Utils\Captcha;
 use App\Utils\PatchTracker;
 use App\Utils\Uploader;
@@ -279,7 +280,8 @@ REPORT;
 			}
 
 			// provide shortcut URLS for "quick bug fixes"
-			list($RESOLVE_REASONS, $FIX_VARIATIONS) = get_resolve_reasons($_GET['project'] ?? false);
+			$reasonRepository = new ReasonRepository($dbh);
+			list($RESOLVE_REASONS, $FIX_VARIATIONS) = $reasonRepository->findByProject($_GET['project'] ?? '');
 
 			$dev_extra = '';
 			$maxkeysize = 0;


### PR DESCRIPTION
This refactors get_resolve_reasons() function to a dedicated repository class and refactors sql to use prepared statements instead of only PDO::quote(). This patch is also already in sync with moving to vanilla PDO only by #60.