### PR TITLE
Refactor bugs_get_bug() to repository

### DIFF
--- a/include/functions.php
+++ b/include/functions.php
@@ -1423,34 +1423,6 @@ function unsubscribe($bug_id, $hash)
 }
 
 /**
- * Fetch bug data
- *
- * @return mixed array of bug data or object with error info
- */
-function bugs_get_bug($bug_id)
-{
-	global $dbh;
-
-	$query = 'SELECT b.id, b.package_name, b.bug_type, b.email, b.reporter_name,
-		b.sdesc, b.ldesc, b.php_version, b.php_os,
-		b.status, b.ts1, b.ts2, b.assign, b.block_user_comment,
-		b.private, b.cve_id,
-		UNIX_TIMESTAMP(b.ts1) AS submitted,
-		UNIX_TIMESTAMP(b.ts2) AS modified,
-		COUNT(bug=b.id) AS votes,
-		IFNULL((SELECT z.project FROM bugdb_pseudo_packages z WHERE z.name = b.package_name LIMIT 1), "php") project,
-		SUM(reproduced) AS reproduced, SUM(tried) AS tried,
-		SUM(sameos) AS sameos, SUM(samever) AS samever,
-		AVG(score)+3 AS average, STD(score) AS deviation
-		FROM bugdb b
-		LEFT JOIN bugdb_votes ON b.id = bug
-		WHERE b.id = ?
-		GROUP BY bug';
-
-	return $dbh->prepare($query)->execute([$bug_id])->fetch();
-}
-
-/**
  * Add bug comment
  */
 function bugs_add_comment($bug_id, $from, $from_name, $comment, $type = 'comment')

--- a/src/Repository/BugRepository.php
+++ b/src/Repository/BugRepository.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Repository;
+
+/**
+ * Repository class for fetching data from the database table bugdb.
+ */
+class BugRepository
+{
+    /**
+     * Database handler.
+     * @var \PDO
+     */
+    private $dbh;
+
+    /**
+     * Class constructor.
+     */
+    public function __construct(\PDO $dbh)
+    {
+        $this->dbh = $dbh;
+    }
+
+    /**
+     * Fetch bug data by bug id.
+     */
+    public function findOneById(int $id): array
+    {
+        $sql = 'SELECT b.id, b.package_name, b.bug_type, b.email, b.reporter_name,
+                    b.sdesc, b.ldesc, b.php_version, b.php_os,
+                    b.status, b.ts1, b.ts2, b.assign, b.block_user_comment,
+                    b.private, b.cve_id,
+                    UNIX_TIMESTAMP(b.ts1) AS submitted,
+                    UNIX_TIMESTAMP(b.ts2) AS modified,
+                    COUNT(bug=b.id) AS votes,
+                    IFNULL((SELECT z.project FROM bugdb_pseudo_packages z WHERE z.name = b.package_name LIMIT 1), "php") project,
+                    SUM(reproduced) AS reproduced, SUM(tried) AS tried,
+                    SUM(sameos) AS sameos, SUM(samever) AS samever,
+                    AVG(score)+3 AS average, STD(score) AS deviation
+                FROM bugdb b
+                LEFT JOIN bugdb_votes ON b.id = bug
+                WHERE b.id = ?
+                GROUP BY bug
+        ';
+
+        $statement = $this->dbh->prepare($sql);
+        $statement->execute([$id]);
+
+        return $statement->fetch();
+    }
+}

--- a/www/bug.php
+++ b/www/bug.php
@@ -1,6 +1,7 @@
 <?php
 /* User interface for viewing and editing bug details */
 
+use App\Repository\BugRepository;
 use App\Repository\CommentRepository;
 use App\Repository\ObsoletePatchRepository;
 use App\Repository\PackageRepository;
@@ -131,7 +132,8 @@ $trytoforce = isset($_POST['trytoforce']) ? (int) $_POST['trytoforce'] : 0;
 
 // fetch info about the bug into $bug
 if (!isset($bug)) {
-	$bug = bugs_get_bug($bug_id);
+	$bugRepository = new BugRepository($dbh);
+	$bug = $bugRepository->findOneById($bug_id);
 }
 
 // DB error

--- a/www/fix.php
+++ b/www/fix.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Repository\BugRepository;
 use App\Repository\ReasonRepository;
 
 session_start();
@@ -19,7 +20,8 @@ if (!$bug_id) {
 bugs_authenticate($user, $pw, $logged_in, $user_flags);
 
 // fetch info about the bug into $bug
-$bug = bugs_get_bug($bug_id);
+$bugRepository = new BugRepository($dbh);
+$bug = $bugRepository->findOneById($bug_id);
 
 if (!is_array($bug)) {
 	response_header('No Such Bug');

--- a/www/gh-pull-add.php
+++ b/www/gh-pull-add.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Repository\BugRepository;
 use App\Repository\PullRequestRepository;
 use App\Utils\Captcha;
 use App\Utils\GitHub;
@@ -26,7 +27,9 @@ if (empty($bug_id)) {
 	exit;
 }
 
-if (!($buginfo = bugs_get_bug($bug_id))) {
+$bugRepository = new BugRepository($dbh);
+
+if (!($buginfo = $bugRepository->findOneById($bug_id))) {
 	response_header('Error :: invalid bug selected');
 	display_bug_error("Invalid bug #{$bug_id} selected");
 	response_footer();

--- a/www/patch-add.php
+++ b/www/patch-add.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Repository\BugRepository;
 use App\Repository\PatchRepository;
 use App\Utils\Captcha;
 use App\Utils\PatchTracker;
@@ -32,7 +33,9 @@ if (empty($bug_id)) {
 	exit;
 }
 
-if (!($buginfo = bugs_get_bug($bug_id))) {
+$bugRepository = new BugRepository($dbh);
+
+if (!($buginfo = $bugRepository->findOneById($bug_id))) {
 	response_header('Error :: invalid bug selected');
 	display_bug_error("Invalid bug #{$bug_id} selected");
 	response_footer();

--- a/www/patch-display.php
+++ b/www/patch-display.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Repository\BugRepository;
 use App\Repository\ObsoletePatchRepository;
 use App\Repository\PatchRepository;
 use App\Utils\PatchTracker;
@@ -40,7 +41,9 @@ if (empty($bug_id)) {
 	$bug_id = (int) $_GET['bug_id'];
 }
 
-if (!($buginfo = bugs_get_bug($bug_id))) {
+$bugRepository = new BugRepository($dbh);
+
+if (!($buginfo = $bugRepository->findOneById($bug_id))) {
 	response_header('Error :: invalid bug selected');
 	display_bug_error("Invalid bug #{$bug_id} selected");
 	response_footer();

--- a/www/rpc.php
+++ b/www/rpc.php
@@ -1,5 +1,7 @@
 <?php
 
+use App\Repository\BugRepository;
+
 /**
  * This API page is used by https://svn.php.net/viewvc/SVNROOT/commit-bugs.php
  * to manage bugs automatically.
@@ -37,7 +39,8 @@ if (empty($auth_user->handle)) {
 }
 
 // fetch info about the bug into $bug
-$bug = bugs_get_bug($bug_id);
+$bugRepository = new BugRepository($dbh);
+$bug = $bugRepository->findOneById($bug_id);
 
 if (!is_array($bug)) {
 	echo json_encode(['result' => ['error' => 'No such bug']]);

--- a/www/rss/bug.php
+++ b/www/rss/bug.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Repository\BugRepository;
 use App\Repository\CommentRepository;
 
 /* Generates an RSS/RDF feed for a particular bug specified as the "id"
@@ -15,7 +16,8 @@ require_once '../../include/prepend.php';
 $bug_id = isset($_REQUEST['id']) ? (int)$_REQUEST['id'] : 0;
 $format = isset($_REQUEST['format']) ? $_REQUEST['format'] : 'rss2';
 
-$bug = bugs_get_bug($bug_id);
+$bugRepository = new BugRepository($dbh);
+$bug = $bugRepository->findOneById($bug_id);
 
 if (!$bug) {
 	header('HTTP/1.0 404 Not Found');


### PR DESCRIPTION
This moves function bugs_get_bug() to its dedicated repository class. Also already synced with the changes introduced in #60.