### PR TITLE
Remove display_bug_success() function

### DIFF
--- a/include/functions.php
+++ b/include/functions.php
@@ -697,18 +697,6 @@ function display_bug_error($in, $class = 'errors', $head = 'ERROR:')
 }
 
 /**
- * Prints a message saying the action succeeded
- *
- * @param string $in	the string to be displayed
- *
- * @return void
- */
-function display_bug_success($in)
-{
-	echo "<div class='success'>{$in}</div>\n";
-}
-
-/**
  * Returns array of changes going to be made
  */
 function bug_diff($bug, $in)

--- a/www/bug-pwd-finder.php
+++ b/www/bug-pwd-finder.php
@@ -70,7 +70,7 @@ echo "<h1>Bug Report Password Finder</h1>\n";
 display_bug_error($errors);
 
 if ($success) {
-	display_bug_success($success);
+	echo '<div class="success">'.$success.'</div>';
 }
 
 $_SESSION['answer'] = $captcha->getAnswer();

--- a/www/bug.php
+++ b/www/bug.php
@@ -596,34 +596,34 @@ switch ($thanks)
 {
 	case 1:
 	case 2:
-		display_bug_success('The bug was updated successfully.');
+		echo '<div class="success">The bug was updated successfully.</div>';
 		break;
 	case 3:
-		display_bug_success('Your comment was added to the bug successfully.');
+		echo '<div class="success">Your comment was added to the bug successfully.</div>';
 		break;
 	case 4:
 		$bug_url = "{$site_method}://{$site_url}{$basedir}/bug.php?id={$bug_id}";
-		display_bug_success("
+		echo '<div class="success">
 			Thank you for your help!
 			If the status of the bug report you submitted changes, you will be notified.
 			You may return here and check the status or update your report at any time.<br>
-			The URL for your bug report is: <a href='{$bug_url}'>{$bug_url}</a>.
-		");
+			The URL for your bug report is: <a href="'.$bug_url.'">'.$bug_url.'</a>.
+			</div>';
 		break;
 	case 6:
-		display_bug_success('Thanks for voting! Your vote should be reflected in the statistics below.');
+		echo '<div class="success">Thanks for voting! Your vote should be reflected in the statistics below.</div>';
 		break;
 	case 7:
-		display_bug_success('Your subscribe request has been processed.');
+		echo '<div class="success">Your subscribe request has been processed.</div>';
 		break;
 	case 8:
-		display_bug_success('Your unsubscribe request has been processed, please check your email.');
+		echo '<div class="success">Your unsubscribe request has been processed, please check your email.</div>';
 		break;
 	case 9:
-		display_bug_success('You have successfully unsubscribed.');
+		echo '<div class="success">You have successfully unsubscribed.</div>';
 		break;
 	case 10:
-		display_bug_success('Your vote has been updated.');
+		echo '<div class="success">Your vote has been updated.</div>';
 	break;
 
 	default:


### PR DESCRIPTION
The `display_bug_success()` is a simple wrapper around the echo and has HTML embedded in it. Instead of using a helper function for this, this can be directly embedded in the two files.