### PR TITLE
Fix #77355: Filing a ticket links to the Edit tab of potential duplicates

### DIFF
--- a/www/report.php
+++ b/www/report.php
@@ -127,7 +127,7 @@ if (isset($_POST['in'])) {
 						$summary = substr(trim($summary), 0, 256) . ' ...';
 					}
 
-					$bug_url = "bug.php?id={$row['id']}&amp;edit=2";
+					$bug_url = "bug.php?id={$row['id']}";
 
 					$sdesc		= htmlspecialchars($row['sdesc']);
 					$summary	= htmlspecialchars($summary);


### PR DESCRIPTION
We should link to the ticket generally, instead of the Edit tab.