### PR TITLE
Remove PHP 5.6 and add PHP 7.4 to "Common searches" list

### DIFF
--- a/www/index.php
+++ b/www/index.php
@@ -47,10 +47,10 @@ if ('/random' === $_SERVER['REQUEST_URI']) {
 $searches = [
     'Most recent open bugs (all)' => '&bug_type=All',
     'Most recent open bugs (all) with patch or pull request' => '&bug_type=All&patch=Y&pull=Y',
-    'Most recent open bugs (PHP 5.6)' => '&bug_type=All&phpver=5.6',
     'Most recent open bugs (PHP 7.1)' => '&bug_type=All&phpver=7.1',
     'Most recent open bugs (PHP 7.2)' => '&bug_type=All&phpver=7.2',
     'Most recent open bugs (PHP 7.3)' => '&bug_type=All&phpver=7.3',
+    'Most recent open bugs (PHP 7.4)' => '&bug_type=All&phpver=7.4',
     'Open Documentation bugs' => '&bug_type=Documentation+Problem',
     'Open Documentation bugs (with patches)' => '&bug_type=Documentation+Problem&patch=Y',
 ];


### PR DESCRIPTION
Remove the PHP 5.6 as isn't support anymore, and add PHP 7.4 as it was already branched and people can start to fill bugs for this version.