### PR TITLE
Do not use suspended status when requesting a random ticked

### DIFF
--- a/src/Repository/BugRepository.php
+++ b/src/Repository/BugRepository.php
@@ -63,7 +63,7 @@ class BugRepository
     {
         $sql = "SELECT id
                 FROM bugdb
-                WHERE status NOT IN('Closed', 'Not a bug', 'Duplicate', 'Spam', 'Wont fix', 'No Feedback')
+                WHERE status NOT IN('Closed', 'Not a bug', 'Duplicate', 'Spam', 'Wont fix', 'No Feedback', 'Suspended')
                     AND private = 'N'
                 ORDER BY RAND() LIMIT 1
         ";


### PR DESCRIPTION
When going to `/random`it's not very useful to see suspended tickets. This PR prevents them from showing up for this case.