### PR TITLE
Prevent XSS in HTML attributes

### DIFF
--- a/src/Template/Context.php
+++ b/src/Template/Context.php
@@ -152,7 +152,14 @@ class Context
      */
     public function e(string $string): string
     {
-        return htmlspecialchars($string, ENT_QUOTES, 'UTF-8');
+        $escapedString = htmlspecialchars($string, ENT_QUOTES, 'UTF-8');
+
+        // prevent XSS in attributes using the javascript: scheme
+        if (stripos($string, 'javascript:') === 0) {
+            $escapedString = sprintf('%s&colon;%s', substr($string, 0, 10), substr($string, 11));
+        }
+
+        return $escapedString;
     }
 
     /**

--- a/tests/Unit/Template/ContextTest.php
+++ b/tests/Unit/Template/ContextTest.php
@@ -80,7 +80,7 @@ class ContextTest extends TestCase
                 'javascript:alert(1)',
                 'javascript&colon;alert(1)',
                 'javascript&colon;alert&lpar;1&rpar;'
-            ]
+            ],
         ];
     }
 }

--- a/tests/Unit/Template/ContextTest.php
+++ b/tests/Unit/Template/ContextTest.php
@@ -75,6 +75,11 @@ class ContextTest extends TestCase
                 '<iframe src="javascript:alert(\'Xss\')";></iframe>',
                 '&lt;iframe src=&quot;javascript:alert(&#039;Xss&#039;)&quot;;&gt;&lt;/iframe&gt;',
                 '&lt;iframe src&equals;&quot;javascript&colon;alert&lpar;&apos;Xss&apos;&rpar;&quot;&semi;&gt;&lt;&sol;iframe&gt;'
+            ],
+            [
+                'javascript:alert(1)',
+                'javascript&colon;alert(1)',
+                'javascript&colon;alert&lpar;1&rpar;'
             ]
         ];
     }


### PR DESCRIPTION
This prevents situations where untrusted input is used in attributes like:

    <iframe src="<?= Context::e('javascript:alert(1)'); ?>";></iframe>

Which will still result in XSS even with `htmlspecialchars()`.