### PR TITLE
Implemented HTTP client

### DIFF
--- a/src/HttpClient/Client.php
+++ b/src/HttpClient/Client.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\HttpClient;
+
+use App\HttpClient\Exception\ConnectionError;
+
+interface Client
+{
+    /**
+     * @throws ConnectionError When a connection could not be established
+     */
+    public function request(Request $request, ?ClientOptions $options = null): Response;
+}

--- a/src/HttpClient/ClientOptions.php
+++ b/src/HttpClient/ClientOptions.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\HttpClient;
+
+class ClientOptions
+{
+    private $timeoutInSeconds = 3;
+
+    public function setTimeout(int $timeoutInSeconds): self
+    {
+        $this->timeoutInSeconds = $timeoutInSeconds;
+
+        return $this;
+    }
+
+    public function getTimeout(): int
+    {
+        return $this->timeoutInSeconds;
+    }
+}

--- a/src/HttpClient/Exception/ConnectionError.php
+++ b/src/HttpClient/Exception/ConnectionError.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace App\HttpClient\Exception;
+
+class ConnectionError extends \Exception
+{
+}

--- a/src/HttpClient/Exception/InvalidHeaderKey.php
+++ b/src/HttpClient/Exception/InvalidHeaderKey.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace App\HttpClient\Exception;
+
+class InvalidHeaderKey extends \Exception
+{
+}

--- a/src/HttpClient/Exception/InvalidHeaderValue.php
+++ b/src/HttpClient/Exception/InvalidHeaderValue.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace App\HttpClient\Exception;
+
+class InvalidHeaderValue extends \Exception
+{
+}

--- a/src/HttpClient/Header.php
+++ b/src/HttpClient/Header.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\HttpClient;
+
+use App\HttpClient\Exception\InvalidHeaderKey;
+use App\HttpClient\Exception\InvalidHeaderValue;
+
+class Header
+{
+    private $key;
+
+    private $normalizedKey;
+
+    private $value;
+
+    /**
+     * @throws InvalidHeaderKey   When a the key contains invalid characters
+     * @throws InvalidHeaderValue When a the value contains invalid characters
+     */
+    public function __construct(string $key, string $value)
+    {
+        if (strpos($key, "\r\n") !== false || strpos($key, ':') !== false) {
+            throw new InvalidHeaderKey();
+        }
+
+        if (strpos($value, "\r\n") !== false) {
+            throw new InvalidHeaderValue();
+        }
+
+        $this->key           = $key;
+        $this->normalizedKey = strtolower($key);
+        $this->value         = $value;
+    }
+
+    public static function createFromString(string $header): self
+    {
+        $headerParts = explode(': ', $header);
+
+        return new self($headerParts[0], $headerParts[1]);
+    }
+
+    public function getKey(): string
+    {
+        return $this->key;
+    }
+
+    public function getNormalizedKey(): string
+    {
+        return $this->normalizedKey;
+    }
+
+    public function getValue(): string
+    {
+        return $this->value;
+    }
+
+    public function toString(): string
+    {
+        return sprintf("%s: %s\r\n", $this->key, $this->value);
+    }
+}

--- a/src/HttpClient/NativeClient.php
+++ b/src/HttpClient/NativeClient.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\HttpClient;
+
+use App\HttpClient\Exception\ConnectionError;
+
+class NativeClient implements Client
+{
+    private $options;
+
+    public function __construct(?ClientOptions $options = null)
+    {
+        $this->options = $options ?? new ClientOptions();
+    }
+
+    public function request(Request $request, ?ClientOptions $options = null): Response
+    {
+        $options = $options ?? $this->options;
+
+        $streamContext = stream_context_create([
+            'http' => [
+                'method'        => $request->getMethod(),
+                'header'        => $request->getHeadersAsString(),
+                'content'       => $request->getBody(),
+                'ignore_errors' => true,
+                'timeout'       => $options->getTimeout(),
+            ],
+        ]);
+
+        $responseBody = @file_get_contents($request->getUri(), false, $streamContext);
+
+        if ($responseBody === false) {
+            throw new ConnectionError(error_get_last()['message']);
+        }
+
+        return new Response($responseBody, ...$http_response_header);
+    }
+}

--- a/src/HttpClient/Request.php
+++ b/src/HttpClient/Request.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace App\HttpClient;
+
+class Request
+{
+    private const DEFAULT_USER_AGENT = 'PHP.net HTTP client';
+
+    private const DEFAULT_POST_CONTENT_TYPE = 'application/x-www-form-urlencoded';
+
+    private $uri;
+
+    private $method;
+
+    private $headers = [];
+
+    private $body;
+
+    public function __construct(string $uri, string $method = 'GET')
+    {
+        $this->uri    = $uri;
+        $this->method = $method;
+
+        $this->headers['user-agent'] = new Header('User-Agent', self::DEFAULT_USER_AGENT);
+
+        if ($method === 'POST') {
+            $this->headers['content-type'] = new Header('Content-Type', self::DEFAULT_POST_CONTENT_TYPE);
+        }
+    }
+
+    public function addHeaders(Header ...$headers): self
+    {
+        foreach ($headers as $header) {
+            $this->headers[$header->getNormalizedKey()] = $header;
+        }
+
+        return $this;
+    }
+
+    public function setBody(string $body): self
+    {
+        $this->body = $body;
+
+        return $this;
+    }
+
+    public function getUri(): string
+    {
+        return $this->uri;
+    }
+
+    public function getMethod(): string
+    {
+        return $this->method;
+    }
+
+    /**
+     * @return Header[]
+     */
+    public function getHeaders(): array
+    {
+        return $this->headers;
+    }
+
+    public function getHeadersAsString(): string
+    {
+        return array_reduce($this->headers, function (string $headers, Header $header) {
+            $headers .= sprintf("%s: %s\r\n", $header->getKey(), $header->getValue());
+
+            return $headers;
+        }, '');
+    }
+
+    public function getBody(): string
+    {
+        if ($this->body === null) {
+            return '';
+        }
+
+        return $this->body;
+    }
+}

--- a/src/HttpClient/Response.php
+++ b/src/HttpClient/Response.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace App\HttpClient;
+
+class Response
+{
+    private const STATUS_LINE_PATTERN = '~^HTTP/(?P<protocolVersion>\d+\.\d+) (?P<statusCode>\d{3})(?: (?P<reasonPhrase>.+))?~';
+
+    private $protocolVersion;
+
+    private $statusCode;
+
+    private $reasonPhrase;
+
+    private $headers = [];
+
+    private $body;
+
+    public function __construct(string $body, string ...$headers)
+    {
+        $this->body = $body;
+
+        $this->parseStatusLine(array_shift($headers));
+
+        foreach ($headers as $header) {
+            $this->headers[] = Header::createFromString($header);
+        }
+    }
+
+    private function parseStatusLine(string $statusLine):void
+    {
+        preg_match(self::STATUS_LINE_PATTERN, $statusLine, $matches);
+
+        $this->protocolVersion = $matches['protocolVersion'];
+        $this->statusCode      = $matches['statusCode'];
+        $this->reasonPhrase    = $matches['reasonPhrase'] ?? null;
+    }
+
+    public function getProtocolVersion(): string
+    {
+        return $this->protocolVersion;
+    }
+
+    public function getStatusCode(): int
+    {
+        return $this->statusCode;
+    }
+
+    public function getReasonPhrase(): ?string
+    {
+        return $this->reasonPhrase;
+    }
+
+    /**
+     * @return Header[]
+     */
+    public function getHeaders(): array
+    {
+        return $this->headers;
+    }
+
+    public function getBody(): string
+    {
+        return $this->body;
+    }
+}

--- a/tests/Unit/HttpClient/ClientOptionsTest.php
+++ b/tests/Unit/HttpClient/ClientOptionsTest.php
@@ -1,0 +1,19 @@
+<?php declare(strict_types=1);
+
+namespace App\Tests\Unit\HttpClient;
+
+use App\HttpClient\ClientOptions;
+use PHPUnit\Framework\TestCase;
+
+class ClientOptionsTest extends TestCase
+{
+    public function testGetTimeoutUsesDefaultValue(): void
+    {
+        $this->assertSame(3, (new ClientOptions())->getTimeout());
+    }
+
+    public function testSetTimeoutSetsValue(): void
+    {
+        $this->assertSame(10, (new ClientOptions())->setTimeout(10)->getTimeout());
+    }
+}

--- a/tests/Unit/HttpClient/HeaderTest.php
+++ b/tests/Unit/HttpClient/HeaderTest.php
@@ -1,0 +1,53 @@
+<?php declare(strict_types=1);
+
+namespace App\Tests\Unit\HttpClient;
+
+use App\HttpClient\Exception\InvalidHeaderKey;
+use App\HttpClient\Exception\InvalidHeaderValue;
+use App\HttpClient\Header;
+use PHPUnit\Framework\TestCase;
+
+class HeaderTest extends TestCase
+{
+    public function testCreateFromStringCorrectlyParsesAHeaderString(): void
+    {
+        $header = Header::createFromString('Foo: Bar');
+
+        $this->assertSame('Foo', $header->getKey());
+        $this->assertSame('Bar', $header->getValue());
+    }
+
+    public function testKeyMaintainsOriginalCasing(): void
+    {
+        $this->assertSame('fOo', (new Header('fOo', 'bar'))->getKey());
+    }
+
+    public function testKeyGetsNormalized(): void
+    {
+        $this->assertSame('foo-foo', (new Header('fOo-FOO', 'bar'))->getNormalizedKey());
+    }
+
+    public function testGetValue(): void
+    {
+        $this->assertSame('bar', (new Header('foo', 'bar'))->getValue());
+    }
+
+    public function testHeaderInjectionIsPreventedOnTheKey(): void
+    {
+        $this->expectException(InvalidHeaderKey::class);
+
+        new Header("foo\r\nbar", 'bar');
+    }
+
+    public function testHeaderInjectionIsPreventedOnTheValue(): void
+    {
+        $this->expectException(InvalidHeaderValue::class);
+
+        new Header('Foo', "foo\r\nbar");
+    }
+
+    public function testToString(): void
+    {
+        $this->assertSame("Foo: Bar\r\n", (new Header('Foo', 'Bar'))->toString());
+    }
+}

--- a/tests/Unit/HttpClient/NativeClientTest.php
+++ b/tests/Unit/HttpClient/NativeClientTest.php
@@ -1,0 +1,71 @@
+<?php declare(strict_types=1);
+
+namespace App\Tests\Unit\HttpClient;
+
+use App\HttpClient\ClientOptions;
+use App\HttpClient\Exception\ConnectionError;
+use App\HttpClient\Header;
+use App\HttpClient\NativeClient;
+use App\HttpClient\Request;
+use PHPUnit\Framework\TestCase;
+
+class NativeClientTest extends TestCase
+{
+    public function testRequestUsesCorrectMethod(): void
+    {
+        $response = (new NativeClient())->request(new Request('https://httpbin.org/post', 'POST'));
+
+        $this->assertSame(200, $response->getStatusCode());
+    }
+
+    public function testRequestSendsHeaders(): void
+    {
+        $request = (new Request('https://httpbin.org/headers'))
+            ->addHeaders(new Header('Foo', 'Bar'))
+        ;
+
+        $response = (new NativeClient())->request($request);
+
+        $headersSent = json_decode($response->getBody(), true)['headers'];
+
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertArrayHasKey('Foo', $headersSent);
+        $this->assertSame('Bar', $headersSent['Foo']);
+        $this->assertArrayHasKey('User-Agent', $headersSent);
+        $this->assertSame('PHP.net HTTP client', $headersSent['User-Agent']);
+    }
+
+    public function testRequestThrowsExceptionOnConnectionErrors(): void
+    {
+        $this->expectException(ConnectionError::class);
+
+        (new NativeClient())->request(new Request('https://httpbin.org/delay/4'));
+    }
+
+    public function testRequestUsesDefaultClientOptions(): void
+    {
+        (new NativeClient())->request(new Request('https://httpbin.org/delay/2'));
+
+        $this->expectException(ConnectionError::class);
+
+        (new NativeClient())->request(new Request('https://httpbin.org/delay/4'));
+    }
+
+    public function testRequestUsesClientOptions(): void
+    {
+        $this->expectException(ConnectionError::class);
+
+        $clientOptions = (new ClientOptions())->setTimeout(1);
+
+        (new NativeClient($clientOptions))->request(new Request('https://httpbin.org/delay/2'));
+    }
+
+    public function testRequestUsesClientOptionsFromRequest(): void
+    {
+        $this->expectException(ConnectionError::class);
+
+        $clientOptions = (new ClientOptions())->setTimeout(1);
+
+        (new NativeClient())->request(new Request('https://httpbin.org/delay/2'), $clientOptions);
+    }
+}

--- a/tests/Unit/HttpClient/RequestTest.php
+++ b/tests/Unit/HttpClient/RequestTest.php
@@ -1,0 +1,117 @@
+<?php declare(strict_types=1);
+
+namespace App\Tests\Unit\HttpClient;
+
+use App\HttpClient\Header;
+use App\HttpClient\Request;
+use PHPUnit\Framework\TestCase;
+
+class RequestTest extends TestCase
+{
+    public function testUriIsCorrectlySet(): void
+    {
+        $this->assertSame('https://example.com', (new Request('https://example.com'))->getUri());
+    }
+
+    public function testDefaultMethodIsSetWhenNoMethodIsSupplied(): void
+    {
+        $this->assertSame('GET', (new Request('https://example.com'))->getMethod());
+    }
+
+    public function testMethodIsSet(): void
+    {
+        $this->assertSame('POST', (new Request('https://example.com', 'POST'))->getMethod());
+    }
+
+    public function testDefaultUserAgentIsSet(): void
+    {
+        $header = (new Request('https://example.com'))->getHeaders()['user-agent'];
+
+        $this->assertSame('PHP.net HTTP client', $header->getValue());
+        $this->assertSame('User-Agent', $header->getKey());
+    }
+
+    public function testDefaultContentTypeIsSetForPostRequests(): void
+    {
+        $header = (new Request('https://example.com', 'POST'))->getHeaders()['content-type'];
+
+        $this->assertSame('application/x-www-form-urlencoded', $header->getValue());
+        $this->assertSame('Content-Type', $header->getKey());
+    }
+
+    public function testAddingSingleHeader(): void
+    {
+        $request = (new Request('https://example.com'))
+            ->addHeaders(new Header('Foo', 'Bar'))
+        ;
+
+        $this->assertArrayHasKey('foo', $request->getHeaders());
+    }
+
+    public function testAddingMultipleHeader(): void
+    {
+        $request = (new Request('https://example.com'))
+            ->addHeaders(
+                new Header('Foo', 'Bar'),
+                new Header('Baz', 'Qux')
+            )
+        ;
+
+        $this->assertArrayHasKey('foo', $request->getHeaders());
+        $this->assertArrayHasKey('baz', $request->getHeaders());
+    }
+
+    public function testAddHeadersOverwritesExistingHeader(): void
+    {
+        $request = (new Request('https://example.com'))
+            ->addHeaders(new Header('User-Agent', 'User agent override'))
+        ;
+
+        $this->assertSame('User agent override', $request->getHeaders()['user-agent']->getValue());
+    }
+
+    public function testGetHeaders(): void
+    {
+        $request = (new Request('https://example.com'))
+            ->addHeaders(
+                new Header('Foo', 'Bar'),
+                new Header('Baz', 'Qux')
+            )
+        ;
+
+        $this->assertCount(3, $request->getHeaders());
+        $this->assertInstanceOf(Header::class, $request->getHeaders()['user-agent']);
+        $this->assertInstanceOf(Header::class, $request->getHeaders()['foo']);
+    }
+
+    public function testGetHeadersAsString(): void
+    {
+        $request = (new Request('https://example.com'))
+            ->addHeaders(
+                new Header('Foo', 'Bar'),
+                new Header('Baz', 'Qux')
+            )
+        ;
+
+        $expectedHeadersString = '';
+
+        $expectedHeadersString .= "User-Agent: PHP.net HTTP client\r\n";
+        $expectedHeadersString .= "Foo: Bar\r\n";
+        $expectedHeadersString .= "Baz: Qux\r\n";
+
+        $this->assertSame($expectedHeadersString, $request->getHeadersAsString());
+    }
+
+    public function testGetBodyReturnsEmptyStringWhenBodyIsNotSet(): void
+    {
+        $this->assertSame('', (new Request('https://example.com'))->getBody());
+    }
+
+    public function testGetBodyReturnsTheBodySet(): void
+    {
+        $this->assertSame(
+            'The request body',
+            (new Request('https://example.com'))->setBody('The request body')->getBody()
+        );
+    }
+}

--- a/tests/Unit/HttpClient/ResponseTest.php
+++ b/tests/Unit/HttpClient/ResponseTest.php
@@ -1,0 +1,48 @@
+<?php declare(strict_types=1);
+
+namespace App\Tests\Unit\HttpClient;
+
+use App\HttpClient\Header;
+use App\HttpClient\Response;
+use PHPUnit\Framework\TestCase;
+
+class ResponseTest extends TestCase
+{
+    public function testGetBody(): void
+    {
+        $this->assertSame('The response body', (new Response('The response body', 'HTTP/1.1 200 OK'))->getBody());
+    }
+
+    public function testParsingOfProtocolVersion(): void
+    {
+        $this->assertSame('1.1', (new Response('', 'HTTP/1.1 200 OK'))->getProtocolVersion());
+    }
+
+    public function testParsingOfStatusCode(): void
+    {
+        $this->assertSame(200, (new Response('', 'HTTP/1.1 200 OK'))->getStatusCode());
+    }
+
+    public function testParsingOfMissingReasonPhrase(): void
+    {
+        $this->assertNull((new Response('', 'HTTP/1.1 200'))->getReasonPhrase());
+    }
+
+    public function testParsingOfReasonPhrase(): void
+    {
+        $this->assertSame('OK', (new Response('', 'HTTP/1.1 200 OK'))->getReasonPhrase());
+    }
+
+    public function testParsingOfHeaders(): void
+    {
+        $response = new Response('', 'HTTP/1.1 200 OK', 'Header1Key: Header1Value', 'Header2Key: Header2Value');
+
+        $this->assertCount(2, $response->getHeaders());
+        $this->assertInstanceOf(Header::class, $response->getHeaders()[0]);
+        $this->assertInstanceOf(Header::class, $response->getHeaders()[1]);
+        $this->assertSame('Header1Key', $response->getHeaders()[0]->getKey());
+        $this->assertSame('Header1Value', $response->getHeaders()[0]->getValue());
+        $this->assertSame('Header2Key', $response->getHeaders()[1]->getKey());
+        $this->assertSame('Header2Value', $response->getHeaders()[1]->getValue());
+    }
+}


### PR DESCRIPTION
Currently mocking (and testing) anything that makes HTTP requests is pretty much impossible due to the tight coupling of `file_get_contents()` calls.

This PR adds an HTTP client (and interface) to make this possible / easier. While also providing a uniform way to make HTTP requests (including error handling and responses).

Todo: when the need arises implement file uploads, but from a quick look through the code base I did see see the need for it yet.

Todo2: when agreed that this PR is a useful addition move away from the direct `fgc()` calls and implement the HTTP client calls instead.