### PR TITLE
Prevent javascript: scheme URLs in href attribute

### DIFF
--- a/templates/pages/index.php
+++ b/templates/pages/index.php
@@ -60,7 +60,7 @@ open bug and see if you can help resolve it. We have made it easy. Hit
 
 <ul>
     <?php foreach ($searches as $title => $link): ?>
-        <li><a href="<?= $this->e($link) ?>"><?= $this->e($title) ?></a></li>
+        <li><a href="<?= $this->noHtml($link) ?>"><?= $this->e($title) ?></a></li>
     <?php endforeach ?>
 </ul>
 


### PR DESCRIPTION
Use `noHtml()` instead of `e()` to escape data in href attribute