### PR TITLE
Convert login, logout and statistics pages to templates

### DIFF
--- a/templates/bug_type_options.php
+++ b/templates/bug_type_options.php
@@ -1,0 +1,17 @@
+<?php if (isset($enableAllOption) && $enableAllOption === true): ?>
+    <option value="All" <?= ($selectedType === 'All') ? 'selected="selected"' : ''; ?>>
+        All
+    </option>
+<?php endif; ?>
+<option value="Bug" <?= ($selectedType === 'Bug') ? 'selected="selected"' : ''; ?>>
+    Bug
+</option>
+<option value="Feature/Change Request" <?= ($selectedType === 'Feature/Change Request') ? 'selected="selected"' : ''; ?>>
+    Feature/Change Request
+</option>
+<option value="Documentation Problem" <?= ($selectedType === 'Documentation Problem') ? 'selected="selected"' : ''; ?>>
+    Documentation Problem
+</option>
+<option value="Security" <?= ($selectedType === 'Security') ? 'selected="selected"' : ''; ?>>
+    Security
+</option>

--- a/templates/layout.php
+++ b/templates/layout.php
@@ -22,7 +22,7 @@
             <a href="/search-howto.php">search howto</a>&nbsp;|&nbsp;
             <a href="/stats.php">statistics</a>&nbsp;|&nbsp;
             <a href="/random">random bug</a>&nbsp;|&nbsp;
-            <?php if ($authIsLoggedIn): ?>
+            <?php if (isset($authIsLoggedIn) && $authIsLoggedIn): ?>
                 <a href="/search.php?cmd=display&assign=<?= $this->e($authUsername) ?>">my bugs</a>&nbsp;|&nbsp;
                     <?php if ('developer' === $authRole): ?>
                         <a href="/admin/">admin</a>&nbsp;|&nbsp;

--- a/templates/pages/logged_out.php
+++ b/templates/pages/logged_out.php
@@ -1,0 +1,7 @@
+<?php $this->extends('layout.php', ['title' => 'Logout']) ?>
+
+<?php $this->start('content') ?>
+
+<p>You've been logged out.</p>
+
+<?php $this->end('content') ?>

--- a/templates/pages/login.php
+++ b/templates/pages/login.php
@@ -1,0 +1,27 @@
+<?php $this->extends('layout.php', ['title' => 'Login']) ?>
+
+<?php $this->start('content') ?>
+
+<?php if ($invalidLogin): ?>
+    <div style="background: #AB1616; padding: 3px; width: 300px; color: #FFF; margin: 3px;">
+        Wrong username or password!
+    </div>
+<?php endif; ?>
+<form method="post" action="login.php">
+    <input type="hidden" name="referer" value="<?= $this->e($referer); ?>">
+    <table>
+        <tr>
+            <th align="right">Username:</th>
+            <td><input type="text" name="user" value="<?= $this->e($username); ?>">@php.net
+        </tr>
+        <tr>
+            <th align="right">Password:</th>
+            <td><input type="password" name="pw">
+        </tr>
+        <tr>
+            <td align="center" colspan="2"><input type="submit" value="Login"></td>
+        </tr>
+    </table>
+</form>
+
+<?php $this->end('content') ?>

--- a/templates/pages/statistics.php
+++ b/templates/pages/statistics.php
@@ -1,0 +1,78 @@
+<?php $this->extends('layout.php', ['title' => 'Bugs Stats']) ?>
+
+<?php $this->start('content') ?>
+
+<form method="get" action="stats.php">
+    <table>
+        <tr>
+            <td style="white-space: nowrap">
+                <strong>Bug Type:</strong>
+                <select class="small" id="bug_type" name="bug_type" onchange="this.form.submit(); return false;">
+                    <?php $this->include('bug_type_options.php', ['enableAllOption' => true, 'selectedType' => $selectedType]); ?>
+                </select>
+                <input class="small" type="submit" name="submitStats" value="Search">
+            </td>
+        </tr>
+    </table>
+</form>
+
+<table style="width: 100%; margin-top: 1em;" class="stats-table">
+    <?php if ($statistics['All']['Total'] === 0): ?>
+        <tr>
+            <td>No bugs found</td>
+        </tr>
+    <?php else: ?>
+        <?php $this->include('statistics_headers.php', ['sortBy' => $sortBy, 'reverseSort' => $reverseSort]); ?>
+        <?php $rowCount = 0; ?>
+        <?php foreach($statistics as $packageName => $packageStatistics): ?>
+            <?php $rowCount++; ?>
+            <?php if ($rowCount % 40 === 0): ?>
+                <?php $this->include('statistics_headers.php', ['isSubHeader' => true, 'sortBy' => $sortBy, 'reverseSort' => $reverseSort]); ?>
+            <?php endif; ?>
+            <tr>
+                <td class="bug_head"><?= $this->e($packageName); ?></td>
+                <td class="bug_bg0"><?= $packageStatistics['Total']; ?></td>
+                <?php $this->include('statistics_value.php', ['class' => 1, 'packageName' => $packageName, 'statistics' => $packageStatistics, 'bugType' => $selectedType, 'status' => 'Closed']); ?>
+                <?php $this->include('statistics_value.php', ['class' => 0, 'packageName' => $packageName, 'statistics' => $packageStatistics, 'bugType' => $selectedType, 'status' => 'Open']); ?>
+                <?php $this->include('statistics_value.php', ['class' => 1, 'packageName' => $packageName, 'statistics' => $packageStatistics, 'bugType' => $selectedType, 'status' => 'Critical']); ?>
+                <?php $this->include('statistics_value.php', ['class' => 0, 'packageName' => $packageName, 'statistics' => $packageStatistics, 'bugType' => $selectedType, 'status' => 'Verified']); ?>
+                <?php $this->include('statistics_value.php', ['class' => 1, 'packageName' => $packageName, 'statistics' => $packageStatistics, 'bugType' => $selectedType, 'status' => 'Analyzed']); ?>
+                <?php $this->include('statistics_value.php', ['class' => 0, 'packageName' => $packageName, 'statistics' => $packageStatistics, 'bugType' => $selectedType, 'status' => 'Assigned']); ?>
+                <?php $this->include('statistics_value.php', ['class' => 1, 'packageName' => $packageName, 'statistics' => $packageStatistics, 'bugType' => $selectedType, 'status' => 'Feedback']); ?>
+                <?php $this->include('statistics_value.php', ['class' => 0, 'packageName' => $packageName, 'statistics' => $packageStatistics, 'bugType' => $selectedType, 'status' => 'No Feedback']); ?>
+                <?php $this->include('statistics_value.php', ['class' => 1, 'packageName' => $packageName, 'statistics' => $packageStatistics, 'bugType' => $selectedType, 'status' => 'Suspended']); ?>
+                <?php $this->include('statistics_value.php', ['class' => 0, 'packageName' => $packageName, 'statistics' => $packageStatistics, 'bugType' => $selectedType, 'status' => 'Not a bug']); ?>
+                <?php $this->include('statistics_value.php', ['class' => 1, 'packageName' => $packageName, 'statistics' => $packageStatistics, 'bugType' => $selectedType, 'status' => 'Duplicate']); ?>
+                <?php $this->include('statistics_value.php', ['class' => 0, 'packageName' => $packageName, 'statistics' => $packageStatistics, 'bugType' => $selectedType, 'status' => 'Wont fix']); ?>
+            </tr>
+        <?php endforeach; ?>
+    <?php endif; ?>
+</table>
+
+<?php if ($statistics['All']['Total'] !== 0): ?>
+    <hr>
+
+    <p><b>PHP Versions for recent bug reports:</b></p>
+
+    <?php foreach ($recentReports as $date => $recentReportsOfDate): ?>
+        <table style="float:left; margin-right:20px">
+            <tr class='bug_header'>
+                <th colspan='2'>
+                    <?= $this->e($date); ?>
+                </th>
+            </tr>
+            <?php foreach ($recentReportsOfDate as $versionInformation): ?>
+                <tr>
+                    <td class='bug_head'>
+                        <?= $this->e($versionInformation['version']); ?>
+                    </td>
+                    <td class='bug_bg1'>
+                        <?= $versionInformation['quantity']; ?>
+                    </td>
+                </tr>
+            <?php endforeach; ?>
+        </table>
+    <?php endforeach; ?>
+<?php endif; ?>
+
+<?php $this->end('content') ?>

--- a/templates/statistics_header.php
+++ b/templates/statistics_header.php
@@ -1,0 +1,5 @@
+<th>
+    <a href="/stats.php?sort_by=<?= $this->noHtml(urlencode($type)); ?>&rev=<?= $sortBy === $type ? (int) !$reverseSort : 1; ?>" class="bug_stats<?= $sortBy === $type ? '_choosen' : ''; ?>">
+        <?= $this->e($type); ?>
+    </a>
+</th>

--- a/templates/statistics_headers.php
+++ b/templates/statistics_headers.php
@@ -1,0 +1,16 @@
+<tr class='bug_header'>
+    <th><?= (!isset($isSubHeader) || $isSubHeader !== true) ? 'Name' : '&nbsp;'; ?></th>
+    <th>&nbsp;</th>
+    <?php $this->include('statistics_header.php', ['sortBy' => $sortBy, 'reverseSort' => $reverseSort, 'type' => 'Closed']); ?>
+    <?php $this->include('statistics_header.php', ['sortBy' => $sortBy, 'reverseSort' => $reverseSort, 'type' => 'Open']); ?>
+    <?php $this->include('statistics_header.php', ['sortBy' => $sortBy, 'reverseSort' => $reverseSort, 'type' => 'Critical']); ?>
+    <?php $this->include('statistics_header.php', ['sortBy' => $sortBy, 'reverseSort' => $reverseSort, 'type' => 'Verified']); ?>
+    <?php $this->include('statistics_header.php', ['sortBy' => $sortBy, 'reverseSort' => $reverseSort, 'type' => 'Analyzed']); ?>
+    <?php $this->include('statistics_header.php', ['sortBy' => $sortBy, 'reverseSort' => $reverseSort, 'type' => 'Assigned']); ?>
+    <?php $this->include('statistics_header.php', ['sortBy' => $sortBy, 'reverseSort' => $reverseSort, 'type' => 'Feedback']); ?>
+    <?php $this->include('statistics_header.php', ['sortBy' => $sortBy, 'reverseSort' => $reverseSort, 'type' => 'No Feedback']); ?>
+    <?php $this->include('statistics_header.php', ['sortBy' => $sortBy, 'reverseSort' => $reverseSort, 'type' => 'Suspended']); ?>
+    <?php $this->include('statistics_header.php', ['sortBy' => $sortBy, 'reverseSort' => $reverseSort, 'type' => 'Not a bug']); ?>
+    <?php $this->include('statistics_header.php', ['sortBy' => $sortBy, 'reverseSort' => $reverseSort, 'type' => 'Duplicate']); ?>
+    <?php $this->include('statistics_header.php', ['sortBy' => $sortBy, 'reverseSort' => $reverseSort, 'type' => 'Wont fix']); ?>
+</tr>

--- a/templates/statistics_value.php
+++ b/templates/statistics_value.php
@@ -1,0 +1,13 @@
+<td class="bug_bg<?= $class; ?>">
+    <?php if (!isset($statistics[$status])): ?>
+        &nbsp;
+    <?php elseif ($packageName === 'All'): ?>
+        <a href="search.php?cmd=display&bug_type=<?= $this->noHtml(urlencode($bugType)); ?>&status=<?= $this->noHtml(urlencode($status)); ?>&by=Any&limit=30">
+            <?= $statistics[$status]; ?>
+        </a>
+    <?php else: ?>
+        <a href="search.php?cmd=display&bug_type=<?= $this->noHtml(urlencode($bugType)); ?>&status=<?= $this->noHtml(urlencode($status)); ?>&package_name[]=<?= $this->noHtml(urlencode($packageName)); ?>&by=Any&limit=30">
+            <?= $statistics[$status]; ?>
+        </a>
+    <?php endif; ?>
+</td>

--- a/www/login.php
+++ b/www/login.php
@@ -8,48 +8,27 @@ if (!empty($_SESSION['user'])) {
     redirect('index.php');
 }
 
-response_header('Login');
+$referer = $_SERVER['HTTP_REFERER'] ?? '';
 
 if (isset($_POST['user'])) {
-  $referer = $_POST['referer'];
+    $referer = $_POST['referer'];
 
-  bugs_authenticate($user, $pwd, $logged_in, $user_flags);
+    bugs_authenticate($user, $pwd, $logged_in, $user_flags);
 
-  if ($logged_in === 'developer') {
-    if (!empty($_POST['referer']) &&
-        preg_match("/^{$site_method}:\/\/". preg_quote($site_url) .'/i', $referer) &&
-        parse_url($referer, PHP_URL_PATH) != '/logout.php') {
-        redirect($referer);
+    if ($logged_in === 'developer') {
+        if (!empty($_POST['referer']) &&
+            preg_match("/^{$site_method}:\/\/". preg_quote($site_url) .'/i', $referer) &&
+            parse_url($referer, PHP_URL_PATH) !== '/logout.php') {
+            redirect($referer);
+        }
+
+        redirect('index.php');
     }
-    redirect('index.php');
-  } else {
-?>
-    <div style="background: #AB1616; padding: 3px; width: 300px; color: #FFF; margin: 3px;">Wrong username or password!</div>
-<?php
-  }
-} else {
-    $referer = isset($_SERVER['HTTP_REFERER']) ? $_SERVER['HTTP_REFERER'] : '';
 }
 
-?>
-
-<form method="post" action="login.php">
-<input type="hidden" name="referer" value="<?php print htmlspecialchars($referer); ?>">
-<table>
- <tr>
-  <th align="right">Username:</th>
-  <td><input type="text" name="user" value="<?php print isset($user) ? htmlspecialchars($user) : ''; ?>">@php.net
- </tr>
- <tr>
-  <th align="right">Password:</th>
-  <td><input type="password" name="pw" value="<?php print isset($pwd) ? htmlspecialchars($pwd) : ''; ?>">
- </tr>
- <tr>
-  <td align="center" colspan="2"><input type="submit" value="Login"></td>
- </tr>
-</table>
-</form>
-
-<?php
-response_footer();
-?>
+echo $template->render('pages/login.php', [
+    'referer'      => $referer,
+    'username'     => $user ?? '',
+    // if we have a posted username and we got here it means the login was invalid
+    'invalidLogin' => isset($_POST['user']),
+]);

--- a/www/logout.php
+++ b/www/logout.php
@@ -11,10 +11,4 @@ if (!isset($_SESSION['user']) || empty($_SESSION['user'])) {
 unset($_SESSION['user']);
 session_destroy();
 
-response_header('Logout');
-
-?>
-
-<p>You've been logged out.</p>
-
-<?php response_footer();
+echo $template->render('pages/logged_out.php');

--- a/www/stats.php
+++ b/www/stats.php
@@ -2,221 +2,81 @@
 
 use App\Repository\BugRepository;
 
-session_start();
-
 // Obtain common includes
 require_once '../include/prepend.php';
 
 // Authenticate
-bugs_authenticate($user, $pw, $logged_in, $user_flags);
+require_once __DIR__ . '/../include/auth.php';
 
-response_header('Bugs Stats');
+$selectedBugType = $_GET['bug_type'] ?? 'All';
+$sortBy          = $_GET['sort_by'] ?? 'Open';
+$reverseSort     = (bool) ($_GET['rev'] ?? 1);
 
-$titles = [
-    'Closed'    => 'Closed',
-    'Open'        => 'Open',
-    'Critical'    => 'Crit',
-    'Verified'    => 'Verified',
-    'Analyzed'    => 'Analyzed',
-    'Assigned'    => 'Assigned',
-    'Feedback'    => 'Fdbk',
-    'No Feedback'    => 'No&nbsp;Fdbk',
-    'Suspended'    => 'Susp',
-    'Not a bug'    => 'Not&nbsp;a&nbsp;bug',
-    'Duplicate'    => 'Dupe',
-    'Wont fix'    => 'Wont&nbsp;Fix',
+//$totalBugs  = 0;
+$statisticsTally = [
+    'All' => [
+        'Total' => 0,
+    ],
 ];
 
-$rev = isset($_GET['rev']) ? $_GET['rev'] : 1;
-$sort_by = isset($_GET['sort_by']) ? $_GET['sort_by'] : 'Open';
-$total = 0;
-$row = [];
-$pkg = [];
-$pkg_tmp = [];
-$pkg_total = [];
-$pkg_names = [];
-$all = [];
-$pseudo = true;
+$statistics = [];
 
-if (!array_key_exists($sort_by, $titles)) {
-    $sort_by = 'Open';
-}
-
-$bug_type = $_GET['bug_type'] ?? 'All';
-$bugRepository = $container->get(BugRepository::class);
-
-foreach ($bugRepository->findAllByBugType($bug_type) as $row) {
-    $pkg_tmp[$row['status']][$row['package_name']] = $row['quant'];
-    @$pkg_total[$row['package_name']] += $row['quant'];
-    @$all[$row['status']] += $row['quant'];
-    @$total += $row['quant'];
-    $pkg_names[$row['package_name']] = 0;
-}
-
-if (count($pkg_tmp)) {
-    foreach ($titles as $key => $val) {
-        if (isset($pkg_tmp[$key]) && is_array($pkg_tmp[$key])) {
-            $pkg[$key] = array_merge($pkg_names, $pkg_tmp[$key]);
-        } else {
-            $pkg[$key] = $pkg_names;
-        }
-    }
-}
-
-if ($total > 0) {
-    if ($rev == 1) {
-        arsort($pkg[$sort_by]);
-    } else {
-        asort($pkg[$sort_by]);
-    }
-}
-?>
-
-<form method="get" action="stats.php">
-    <table>
-        <tr>
-            <td style="white-space: nowrap">
-                <strong>Bug Type:</strong>
-                <select class="small" id="bug_type" name="bug_type" onchange="this.form.submit(); return false;">
-                    <?php show_type_options($bug_type, true) ?>
-                </select>
-                <input class="small" type="submit" name="submitStats" value="Search">
-            </td>
-        </tr>
-    </table>
-</form>
-
-<table style="width: 100%; margin-top: 1em;" class="stats-table">
-
-<?php // Exit if there are no bugs for this version
-
-if ($total == 0) {
-    echo '<tr><td>No bugs found</td></tr></table>' . "\n";
-    response_footer();
-    exit;
-}
-
-echo display_stat_header($total, true);
-
-echo <<< OUTPUT
-    <tr>
-        <td class="bug_head">All</td>
-        <td class="bug_bg0">{$total}</td>
-OUTPUT;
-
-$i = 1;
-foreach ($titles as $key => $val) {
-    echo '        <td class="bug_bg' , $i++ % 2 , '">';
-    echo bugstats($key, 'all') , "</td>\n";
-}
-echo "    </tr>\n";
-
-$stat_row = 1;
-foreach ($pkg[$sort_by] as $name => $value) {
-    if ($name != 'all') {
-        // Output a new header row every 40 lines
-        if (($stat_row++ % 40) == 0) {
-            echo display_stat_header($total, false);
-        }
-        echo <<< OUTPUT
-    <tr>
-        <td class="bug_head">{$name}</td>
-        <td class="bug_bg0">{$pkg_total[$name]}</td>
-OUTPUT;
-
-        $i = 1;
-        foreach ($titles as $key => $val) {
-            echo '        <td class="bug_bg', $i++ % 2, '">';
-            echo bugstats($key, $name), "</td>\n";
-        }
-        echo "    </tr>\n";
-    }
-}
-
-echo "</table>\n<hr>\n<p><b>PHP Versions for recent bug reports:</b></p><div>";
-
-$last_date = null;
-foreach ($bugRepository->findPhpVersions($bug_type) as $row) {
-    if ($row['d'] != $last_date) {
-        if ($last_date !== null) {
-            echo "</table>\n\n";
-        }
-        echo "<table style='float:left; margin-right:20px'>\n".
-             "<tr class='bug_header'><th colspan='2'>{$row["d"]}</th></tr>\n";
-        $last_date = $row['d'];
-    }
-    $version = htmlentities($row["formatted_version"], ENT_QUOTES, 'UTF-8');
-    echo "<tr><td class='bug_head'>{$version}</td><td class='bug_bg1'>{$row["quant"]}</td></tr>\n";
-}
-if ($last_date) {
-    echo "</table>\n";
-}
-echo "</div>\n";
-
-response_footer();
-
-// Helper functions
-
-function bugstats($status, $name)
-{
-    global $pkg, $all, $bug_type;
-
-    if ($name == 'all') {
-        if (isset($all[$status])) {
-            return '<a href="search.php?cmd=display&amp;' .
-                   'bug_type='.$bug_type.'&amp;status=' .$status .
-                   '&amp;by=Any&amp;limit=30">' .
-                   $all[$status] . "</a>\n";
-        }
-    } else {
-        if (empty($pkg[$status][$name])) {
-            return '&nbsp;';
-        } else {
-            return '<a href="search.php?cmd=display&amp;'.
-                   'bug_type='.$bug_type.'&amp;status=' .
-                   $status .
-                   '&amp;package_name%5B%5D=' . urlencode($name) .
-                   '&amp;by=Any&amp;limit=30">' .
-                   $pkg[$status][$name] . "</a>\n";
-        }
-    }
-}
-
-function sort_url($name)
-{
-    global $sort_by, $rev, $titles;
-
-    if ($name == $sort_by) {
-        $reve = (int) !$rev;
-    } else {
-        $reve = 1;
-    }
-    if ($sort_by != $name) {
-        $attr = 'class="bug_stats"';
-    } else {
-        $attr = 'class="bug_stats_choosen"';
-    }
-    return '<a href="stats.php?sort_by=' . urlencode($name) .
-           '&amp;rev=' . $reve . '" ' . $attr . '>' .
-           $titles[$name] . '</a>';
-}
-
-function display_stat_header($total, $grandtotal = true)
-{
-    global $titles;
-
-    $stat_head  = " <tr class='bug_header'>\n";
-    if ($grandtotal) {
-        $stat_head .= "  <th>Name</th>\n";
-    } else {
-        $stat_head .= "  <th>&nbsp;</th>\n";
-    }
-    $stat_head .= "  <th>&nbsp;</th>\n";
-
-    foreach ($titles as $key => $val) {
-        $stat_head .= '  <th>' . sort_url($key) . "</th>\n";
+// massage the stats per package into a workable data structure for presentation on the page
+foreach ($container->get(BugRepository::class)->findAllByBugType($selectedBugType) as $packageAndStatus) {
+    if (!isset($statistics[$packageAndStatus['package_name']])) {
+        $statistics[$packageAndStatus['package_name']] = [
+            'Total' => 0,
+        ];
     }
 
-    $stat_head .= '</tr>' . "\n";
-    return $stat_head;
+    $statistics[$packageAndStatus['package_name']][$packageAndStatus['status']] = $packageAndStatus['quant'];
+
+    $statistics[$packageAndStatus['package_name']]['Total'] += $packageAndStatus['quant'];
+
+    $statisticsTally['All']['Total'] += $packageAndStatus['quant'];
+
+    if (!isset($statisticsTally['All'][$packageAndStatus['status']])) {
+        $statisticsTally['All'][$packageAndStatus['status']] = 0;
+    }
+
+    $statisticsTally['All'][$packageAndStatus['status']] += $packageAndStatus['quant'];
 }
+
+uasort($statistics, function (array $a, array $b) use ($sortBy) {
+    if (!isset($a[$sortBy])) {
+        return -1;
+    }
+
+    if (!isset($b[$sortBy])) {
+        return 1;
+    }
+
+    return $a[$sortBy] <=> $b[$sortBy];
+});
+
+if ($reverseSort) {
+    arsort($statistics);
+}
+
+$statistics = array_merge($statisticsTally, $statistics);
+
+$recentReports = [];
+
+foreach ($container->get(BugRepository::class)->findPhpVersions($selectedBugType) as $recentBugs) {
+    if (!isset($recentReports[$recentBugs['d']])) {
+        $recentReports[$recentBugs['d']] = [];
+    }
+
+    $recentReports[$recentBugs['d']][] = [
+        'version'  => $recentBugs['formatted_version'],
+        'quantity' => $recentBugs['quant'],
+    ];
+}
+
+echo $template->render('pages/statistics.php', [
+    'selectedType'  => $selectedBugType,
+    'sortBy'        => $sortBy,
+    'reverseSort'   => $reverseSort,
+    'statistics'    => $statistics,
+    'recentReports' => $recentReports,
+]);


### PR DESCRIPTION
I converted 3 pages to use templates:

- login (https://bugs.php.net/login.php)
- logout (https://bugs.php.net/logout.php)
- statistics (http://bugs.php.local/stats.php)

Next up would be the report-a-bug page, but that needs some more thought as there is a lot going on on that page.