### PR TITLE
Use numeric input-mode for captcha

### DIFF
--- a/www/report.php
+++ b/www/report.php
@@ -549,7 +549,7 @@ display_bug_error($errors);
 ?>
             <tr>
                 <th><?php echo $captcha_label; ?><br><?php echo htmlspecialchars($captcha->getQuestion()); ?></th>
-                <td class="form-input"><input type="text" name="captcha" autocomplete="off"></td>
+                <td class="form-input"><input type="number" inputmode="numeric" pattern="[0-9]*" name="captcha" autocomplete="off"></td>
             </tr>
 <?php } ?>
 


### PR DESCRIPTION
which activates the number only keyboard on ios

See http://danielfriesen.name/blog/2013/09/19/input-type-number-and-ios-numeric-keypad/

Without this change the user has to switch to a numeric keyboard everytime the keyboard is opened for entering the captcha