### PR TITLE
Added a confirm prompt to Subscribe/Unsubscribe button

### DIFF
--- a/www/bug.php
+++ b/www/bug.php
@@ -1037,8 +1037,8 @@ if (!$logged_in) {
         <tr>
             <th class="details">Subscribe to this entry?</th>
             <td class="form-input">
-                <input type="submit" name="subscribe_to_bug" value="Subscribe">
-                <input type="submit" name="unsubscribe_to_bug" value="Unsubscribe">
+                <input type="submit" name="subscribe_to_bug" value="Subscribe" onclick="if (document.querySelector('[name=ncomment]').value.length) return confirm('You will lose your typed comment, when subscribe. proceed?');">
+                <input type="submit" name="unsubscribe_to_bug" value="Unsubscribe" onclick="if (document.querySelector('[name=ncomment]').value.length) return confirm('You will lose your typed comment, when unsubscribe. proceed?');">
             </td>
         </tr>
     </table>


### PR DESCRIPTION
In the past I lost my changes several times, because after typing in the wrong captcha and a site-reload I used the wrong button to submit the form.

Before this change a already typed comment would be lost easily when accidally pushing 
one of the 'Subscribe' or 'Unsubscribe' buttons.

After this change a additional prompt will show up, when the comment-textarea is not empty at the time you click 'Subscribe' or 'Unsubscribe'.
When the textarea is empty no prompt is shown and everything works like before