### PR TITLE
Group by needs to specifically reference a column name, not a variable.

### DIFF
--- a/src/Repository/BugRepository.php
+++ b/src/Repository/BugRepository.php
@@ -45,7 +45,7 @@ class BugRepository
                 FROM bugdb b
                 LEFT JOIN bugdb_votes ON b.id = bug
                 WHERE b.id = ?
-                GROUP BY bug
+                GROUP BY b.id
         ';
 
         $statement = $this->dbh->prepare($sql);


### PR DESCRIPTION
Pulling this out of the other pull request. The query is ambiguous and fails when ONLY_FULL_GROUP_BY is enabled...which is probably a good thing to do, and is on for the docker environment.