### PR TITLE
fix a fatal error when passed null to e()

### DIFF
--- a/templates/pages/admin/database_status.php
+++ b/templates/pages/admin/database_status.php
@@ -61,7 +61,7 @@
                 <td class="bug_bg1"><?= $tableStatus['Data_free']; ?></td>
                 <td class="bug_bg0"><?= $tableStatus['Auto_increment']; ?></td>
                 <td class="bug_bg1"><?= $this->e($tableStatus['Create_time']); ?></td>
-                <td class="bug_bg0"><?= $this->e($tableStatus['Update_time']); ?></td>
+                <td class="bug_bg0"><?= $this->e($tableStatus['Update_time']?:''); ?></td>
                 <td class="bug_bg1"><?php echo $tableStatus['Check_time'] ? $this->e($tableStatus['Check_time']) : ''; ?></td>
                 <td class="bug_bg0"><?= $this->e($tableStatus['Collation']); ?></td>
                 <td class="bug_bg1"><?php echo $tableStatus['Checksum'] ? $this->e($tableStatus['Checksum']) : ''; ?></td>


### PR DESCRIPTION
Fatal error: Uncaught TypeError: Argument 1 passed to App\Template\Context::e() must be of the type string, null given, called in /srv/www/htdocs/web-bugs/templates/pages/admin/database_status.php on line 64 and defined in /srv/www/htdocs/web-bugs/src/Template/Context.php:159