### PR TITLE
recent bugs stat floating table fix

### DIFF
--- a/www/css/style.css
+++ b/www/css/style.css
@@ -273,6 +273,12 @@ a.bug_stats_choosen {
     background-color: #aabbcc;
 }
 
+.bugstatrecent table {
+    display:inline-block;
+    vertical-align:top;
+    margin-right:1em;
+    margin-top:1em;
+}
 /* ========= Other ========= */
 
 a:link {

--- a/www/stats.php
+++ b/www/stats.php
@@ -133,7 +133,9 @@ OUTPUT;
     }
 }
 
-echo "</table>\n<hr>\n<p><b>PHP Versions for recent bug reports:</b></p><div>";
+echo "</table>\n<hr>\n<p><b>PHP Versions for recent bug reports:</b></p>";
+                    
+echo '<div class="bugstatrecent">';
 
 $last_date = null;
 foreach ($bugRepository->findPhpVersions($bug_type) as $row) {
@@ -141,7 +143,7 @@ foreach ($bugRepository->findPhpVersions($bug_type) as $row) {
         if ($last_date !== null) {
             echo "</table>\n\n";
         }
-        echo "<table style='float:left; margin-right:20px'>\n".
+        echo "<table>\n".
              "<tr class='bug_header'><th colspan='2'>{$row["d"]}</th></tr>\n";
         $last_date = $row['d'];
     }


### PR DESCRIPTION
Using float:left; for a liquid layout of the monthly stats wraps odd:
![recentbugsstat](https://user-images.githubusercontent.com/1839154/131915373-ac32fbb5-ef3c-4ed6-91e7-d9f915d3d514.png)

Removing inline css and replacing it with display:inline-block; fixes this and offers greater flexibility:
![recentbugstatfix](https://user-images.githubusercontent.com/1839154/131915394-1a8ce7dd-089a-453e-a0b2-db86680219d7.png)
