### PR TITLE
fix js error when resizing package group select

### DIFF
--- a/www/js/package-affected.js
+++ b/www/js/package-affected.js
@@ -65,7 +65,9 @@ window.addEventListener(
                             moveOptions(select, previousGroup);
                         }
 
-                        moveOptions(nextGroup, select);
+                        if (nextGroup !== null) {
+                            moveOptions(nextGroup, select);
+                        }
 
                         select.selectedIndex = -1;
                     }


### PR DESCRIPTION
When opening https://bugs.php.net/report.php and there is no package group yet selected and someone resizes the package group select, the change event is triggered and the moveOptions function is called with a null parameter.

![phpbgjserror](https://user-images.githubusercontent.com/1839154/133893262-4cd96690-d364-49a5-b36b-6bad4a004236.png)