### PR TITLE
top align selects on report.php

### DIFF
--- a/www/css/style.css
+++ b/www/css/style.css
@@ -158,6 +158,7 @@ input {
 
 select {
     resize: both;
+    vertical-align:top;
 }
 
 textarea {


### PR DESCRIPTION
With the new flexibility of resizing the package category select the appearing of the 2 selects side by side on https://bugs.php.net/report.php might look a bit weird.

This PR fixes it by align the 2 selects always to the top.

![reportnewselects](https://user-images.githubusercontent.com/1839154/133894927-5826c227-b858-46b4-85c7-34125287ba6b.png)