### PR TITLE
fix typo in tests/bootstrap.php

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -2,6 +2,6 @@
 
 require_once __DIR__ . '/../vendor/autoload.php';
 
-define('TEST_FIXTURES_DIRECTORY', __DIR__ . '/Fixtures');
+define('TEST_FIXTURES_DIRECTORY', __DIR__ . '/fixtures');
 define('TEST_MOCKS_DIRECTORY', __DIR__ . '/Mocks');
 define('TEST_VAR_DIRECTORY', __DIR__ . '/../var');


### PR DESCRIPTION
I had to fix the path there to enable running the phpunit tests.