### PR TITLE
Disable submission of "Documentation Problem" bugs

### DIFF
--- a/include/functions.php
+++ b/include/functions.php
@@ -457,11 +457,12 @@ function show_limit_options($limit = 30)
  * Options include "Bug", "Documentation Problem" and "Feature/Change Request."
  *
  * @param string    $current    bug's current type
- * @param bool        $all        whether or not 'All' should be an option
+ * @param bool      $deprecated whether or not deprecated types should be shown
+ * @param bool      $all        whether or not 'All' should be an option
  *
  * @retun void
  */
-function show_type_options($current = 'Bug', $all = false)
+function show_type_options($current, $deprecated, $all = false)
 {
     global $bug_types;
 
@@ -479,6 +480,9 @@ function show_type_options($current = 'Bug', $all = false)
     }
 
     foreach ($bug_types as $k => $v) {
+        if ($k === 'Documentation Problem' && !$deprecated) {
+            continue;
+        }
         $selected = strcasecmp($current, $k) ? '' : ' selected="selected"';
         $k = htmlentities($k, ENT_QUOTES);
         echo "<option value=\"$k\"$selected>$k</option>";

--- a/www/bug.php
+++ b/www/bug.php
@@ -928,7 +928,7 @@ if ($edit == 1 || $edit == 2) { ?>
             <th class="details">Bug Type:</th>
             <td colspan="3">
                 <select name="in[bug_type]">
-                    <?php show_type_options($bug['bug_type']); ?>
+                    <?php show_type_options($bug['bug_type'], /* deprecated */ true); ?>
                 </select>
             </td>
         </tr>

--- a/www/report.php
+++ b/www/report.php
@@ -376,7 +376,11 @@ if (!isset($_POST['in'])) {
         <strong>Failure to follow these instructions may result in your bug simply being marked as &quot;not a bug.&quot;</strong>
     </p>
 
-    <p>Report <img src="images/pear_item.gif"><b>PEAR</b> related bugs <a href="https://pear.php.net/bugs/">here</a></p>
+    <p style="background-color: #ffa;">
+        <strong>Documentation issues should now be reported on the <a href="https://github.com/php/doc-en/issues">php/doc-en</a> repository.</strong>
+    </p>
+
+    <p>Report <img src="images/pear_item.gif"><b>PEAR</b> related bugs <a href="https://pear.php.net/bugs/">here</a>.</p>
 
     <p>
         <strong>If you feel this bug concerns a security issue, e.g. a buffer overflow, weak encryption, etc, then email
@@ -445,7 +449,7 @@ display_bug_error($errors);
                 <th class="form-label_left">Bug Type:</th>
                 <td class="form-input">
                     <select name="in[bug_type]">
-                        <?php show_type_options($_POST['in']['bug_type']); ?>
+                        <?php show_type_options($_POST['in']['bug_type'], /* deprecated */ false); ?>
                     </select>
                 </td>
             </tr>

--- a/www/search.php
+++ b/www/search.php
@@ -250,7 +250,7 @@ display_bug_error($warnings, 'warnings', 'WARNING:');
   <td style="white-space: nowrap">
    <label for="bug_type">Return bugs with <b>type</b></label>
   </td>
-  <td><select id="bug_type" name="bug_type"><?php show_type_options($bug_type, true);?></select></td>
+  <td><select id="bug_type" name="bug_type"><?php show_type_options($bug_type, /* deprecated */ true, /* all */ true);?></select></td>
 </tr>
 <tr valign="top">
   <th>Project</th>

--- a/www/stats.php
+++ b/www/stats.php
@@ -78,7 +78,7 @@ if ($total > 0) {
             <td style="white-space: nowrap">
                 <strong>Bug Type:</strong>
                 <select class="small" id="bug_type" name="bug_type" onchange="this.form.submit(); return false;">
-                    <?php show_type_options($bug_type, true) ?>
+                    <?php show_type_options($bug_type, /* deprecated */ true, /* all */ true) ?>
                 </select>
                 <input class="small" type="submit" name="submitStats" value="Search">
             </td>


### PR DESCRIPTION
Instead point people to the php/doc-en repository.

It's still possible to change the bug type to "Documentation
Problem" after it has been submitted, e.g. if it turns out a bug
is really a documentation issue.