### PR TITLE
add the required attribute to report bug form inputs

### DIFF
--- a/www/report.php
+++ b/www/report.php
@@ -411,7 +411,7 @@ display_bug_error($errors);
             <tr>
                 <th class="form-label_left">Y<span class="accesskey">o</span>ur email address:<br><strong>MUST BE VALID</strong></th>
                     <td class="form-input">
-                        <input type="text" size="20" maxlength="40" name="in[email]" value="<?php echo htmlspecialchars($_POST['in']['email'], ENT_COMPAT, 'UTF-8'); ?>" accesskey="o">
+                        <input type="email" size="20" maxlength="40" name="in[email]" required="required" value="<?php echo htmlspecialchars($_POST['in']['email'], ENT_COMPAT, 'UTF-8'); ?>" accesskey="o">
                     </td>
                 </th>
             </tr>
@@ -419,7 +419,7 @@ display_bug_error($errors);
             <tr>
                 <th class="form-label_left"><span class="accesskey">P</span>assword:</th>
                 <td class="form-input">
-                    <input type="password" size="20" maxlength="20" name="in[passwd]" value="<?php echo htmlspecialchars($_POST['in']['passwd'], ENT_COMPAT, 'UTF-8');?>" accesskey="p"><br>
+                    <input type="password" size="20" maxlength="20" name="in[passwd]" required="required" value="<?php echo htmlspecialchars($_POST['in']['passwd'], ENT_COMPAT, 'UTF-8');?>" accesskey="p"><br>
                     You <strong>must</strong> enter any password here, which will be stored for this bug report.<br>
                     This password allows you to come back and modify your submitted bug report at a later date.
                     [<a href="bug-pwd-finder.php">Lost a bug password?</a>]
@@ -430,7 +430,7 @@ display_bug_error($errors);
             <tr>
                 <th class="form-label_left">PHP version:</th>
                 <td class="form-input">
-                    <select name="in[php_version]">
+                    <select name="in[php_version]" required="required">
                         <?php show_version_options($_POST['in']['php_version']); ?>
                     </select>
                 </td>
@@ -439,7 +439,7 @@ display_bug_error($errors);
             <tr>
                 <th class="form-label_left">Package affected:</th>
                 <td class="form-input">
-                    <select name="in[package_name]">
+                    <select name="in[package_name]" required="required">
                         <?php show_package_options($_POST['in']['package_name'], 0, htmlspecialchars($package)); ?>
                     </select>
                 </td>
@@ -448,7 +448,7 @@ display_bug_error($errors);
             <tr>
                 <th class="form-label_left">Bug Type:</th>
                 <td class="form-input">
-                    <select name="in[bug_type]">
+                    <select name="in[bug_type]" required="required">
                         <?php show_type_options($_POST['in']['bug_type'], /* deprecated */ false); ?>
                     </select>
                 </td>
@@ -464,7 +464,7 @@ display_bug_error($errors);
             <tr>
                 <th class="form-label_left">Summary:</th>
                 <td class="form-input">
-                    <input type="text" size="40" maxlength="79" name="in[sdesc]" value="<?php echo htmlspecialchars($_POST['in']['sdesc'], ENT_COMPAT, 'UTF-8'); ?>">
+                    <input type="text" size="40" maxlength="79" name="in[sdesc]" required="required" value="<?php echo htmlspecialchars($_POST['in']['sdesc'], ENT_COMPAT, 'UTF-8'); ?>">
                 </td>
             </tr>
 
@@ -492,7 +492,7 @@ display_bug_error($errors);
                     </p>
                 </th>
                 <td class="form-input">
-                    <textarea cols="80" rows="15" name="in[ldesc]" wrap="soft"><?php echo htmlspecialchars($_POST['in']['ldesc'], ENT_COMPAT, 'UTF-8'); ?></textarea>
+                    <textarea cols="80" rows="15" name="in[ldesc]" wrap="soft" required="required"><?php echo htmlspecialchars($_POST['in']['ldesc'], ENT_COMPAT, 'UTF-8'); ?></textarea>
                 </td>
             </tr>
             <tr>
@@ -553,7 +553,7 @@ display_bug_error($errors);
 ?>
             <tr>
                 <th><?php echo $captcha_label; ?><br><?php echo htmlspecialchars($captcha->getQuestion()); ?></th>
-                <td class="form-input"><input type="text" name="captcha" autocomplete="off"></td>
+                <td class="form-input"><input type="text" name="captcha" autocomplete="off" required="required"></td>
             </tr>
 <?php } ?>
 


### PR DESCRIPTION
Reduces frustration of reporter as the form is very long and easy to oversee a required input field.

Also enables to style the fields that are required. (like input[required], input:valid, input:invalid)

(I always prefer the compatible XHTML way of ' required="required"' instead of just HTML5 way ' required', so when testing in xhtml mode I get alerted of HTML nesting errors while in HTML5 the browser just do silent heuristic fixes.)