### PR TITLE
reduce cognitive noise in search result table

### DIFF
--- a/www/search.php
+++ b/www/search.php
@@ -156,14 +156,17 @@ if (isset($_GET['cmd']) && $_GET['cmd'] == 'display')
 
                 // Bug ID
                 echo '  <td align="center"><a href="bug.php?id=', $row['id'], '">', $row['id'], '</a>';
-                echo '<br><a href="bug.php?id=', $row['id'], '&amp;edit=1">(edit)</a></td>', "\n";
+                if (is_string($logged_in) && $logged_in === 'developer') {
+                    echo '<br><a href="bug.php?id=', $row['id'], '&amp;edit=1">(edit)</a>';
+                }
+                echo '</td>'."\n";
 
                 // Date
-                echo '  <td align="center">', format_date(strtotime($row['ts1'])), "</td>\n";
+                echo '  <td align="center">', format_date(strtotime($row['ts1'], 'Y-m-d H:i')), "</td>\n";
 
                 // Last Modified
                 $ts2 = strtotime($row['ts2']);
-                echo '  <td align="center">' , ($ts2 ? format_date($ts2) : 'Not modified') , "</td>\n";
+                echo '  <td align="center">' , ($ts2 ? format_date($ts2, 'Y-m-d H:i') : '') , "</td>\n";
 
                 // Package
                 if ($package_count !== 1) {


### PR DESCRIPTION
* There is no need for the edit bug link if it is an anon or non-developer user. (A later iteration might address the redundant view bug tabs too and unite these views.)

* UTC in every result line is not necessary as there is only one offset in database (in fact the datetime field has no offset stored), showing it is always UTC can move to column header. The time itself is probably also not important for this column but lets do it slowly.

* Showing just an empty cell in the 'Last Modified' column is much less burden to visual scan the result table than the string 'Not modified'.

![bugsphpnet_utc_noeditlink](https://user-images.githubusercontent.com/1839154/139505156-5699af00-c3a8-4f11-ab90-5e2f0e24fe3c.png)