### PR TITLE
GH-114: Lock down bug tracker to developers only

### DIFF
--- a/www/bug.php
+++ b/www/bug.php
@@ -1288,5 +1288,5 @@ function control($num, $desc)
 
 function canvote($thanks, $status)
 {
-    return ($thanks != 4 && $thanks != 6 && $status != 'Closed' && $status != 'Not a bug' && $status != 'Duplicate');
+    return false;
 }

--- a/www/bug.php
+++ b/www/bug.php
@@ -1109,7 +1109,9 @@ if ($show_bug_info && $bug_id != 'PREVIEW' && $bug['status'] !== 'Spam') {
 <br>
 OUTPUT;
     }
-    echo "<p><a href='patch-add.php?bug_id={$bug_id}'>Add a Patch</a></p>";
+    if ($logged_in) {
+        echo "<p><a href='patch-add.php?bug_id={$bug_id}'>Add a Patch</a></p>";
+    }
 
     $pullRequestRepository = $container->get(PullRequestRepository::class);
     $pulls = $pullRequestRepository->findAllByBugId($bug_id);

--- a/www/bug.php
+++ b/www/bug.php
@@ -185,7 +185,7 @@ $RESOLVE_REASONS = $FIX_VARIATIONS = $pseudo_pkgs = [];
 $project = $bug['project'];
 
 // Only fetch stuff when it's really needed
-if ($edit && $edit < 3) {
+if ($edit && $edit < 2) {
     $packageRepository = $container->get(PackageRepository::class);
     $pseudo_pkgs = $packageRepository->findEnabled();
 }
@@ -210,11 +210,10 @@ if (isset($_POST['ncomment']) && !isset($_POST['preview']) && $edit == 3) {
     // Check if session answer is set, then compare it with the post captcha value.
     // If it's not the same, then it's an incorrect password.
     if (!$logged_in) {
-        if (!isset($_SESSION['answer'])) {
-            $errors[] = 'Please enable cookies so the Captcha system can work';
-        } elseif ($_POST['captcha'] != $_SESSION['answer']) {
-            $errors[] = 'Incorrect Captcha';
-        }
+        response_header('Developers only');
+        display_bug_error('Only developers are allowed to comment; if you are the original reporter use the Edit tab');
+        response_footer();
+        exit;
     }
 
     $ncomment = trim($_POST['ncomment']);
@@ -719,7 +718,6 @@ if (!$show_bug_info) {
 if ($bug_id !== 'PREVIEW') {
     echo '<div class="controls">', "\n",
         control(0, 'View'),
-        ($bug['private'] == 'N' ? control(3, 'Add Comment') : ''),
         control(1, 'Developer'),
         (!$email || $bug['email'] == $email? control(2, 'Edit') : ''),
         '</div>', "\n";
@@ -804,9 +802,7 @@ if ($edit == 1 || $edit == 2) { ?>
         <?php if (!isset($_POST['in'])) { ?>
             Welcome back! If you're the original bug submitter, here's
             where you can edit the bug or add additional notes.<br>
-            If this is not your bug, you can
-            <a href="bug.php?id=<?php echo $bug_id; ?>&amp;edit=3">add a comment by following this link</a>.<br>
-            If this is your bug, but you forgot your password, <a href="bug-pwd-finder.php?id=<?php echo $bug_id; ?>">you can retrieve your password here</a>.<br>
+            If you forgot your password, <a href="bug-pwd-finder.php?id=<?php echo $bug_id; ?>">you can retrieve your password here</a>.<br>
         <?php } ?>
 
             <table>
@@ -831,8 +827,7 @@ if ($edit == 1 || $edit == 2) { ?>
 ?>
         <div class="explain">
             Welcome! If you don't have a Git account, you can't do anything here.<br>
-            You can <a href="bug.php?id=<?php echo $bug_id; ?>&amp;edit=3">add a comment by following this link</a>
-            or if you reported this bug, you can <a href="bug.php?id=<?php echo $bug_id; ?>&amp;edit=2">edit this bug over here</a>.
+            If you reported this bug, you can <a href="bug.php?id=<?php echo $bug_id; ?>&amp;edit=2">edit this bug over here</a>.
             <div class="details">
                 <label for="svnuser">php.net Username:</label>
                 <input type="text" id="svnuser" name="user" value="<?php echo htmlspecialchars($user); ?>" size="10" maxlength="20">

--- a/www/bug.php
+++ b/www/bug.php
@@ -185,7 +185,7 @@ $RESOLVE_REASONS = $FIX_VARIATIONS = $pseudo_pkgs = [];
 $project = $bug['project'];
 
 // Only fetch stuff when it's really needed
-if ($edit && $edit < 2) {
+if ($edit && $edit < 3) {
     $packageRepository = $container->get(PackageRepository::class);
     $pseudo_pkgs = $packageRepository->findEnabled();
 }

--- a/www/fix.php
+++ b/www/fix.php
@@ -73,8 +73,7 @@ if ($logged_in == 'developer') {
 <?php } else { ?>
     <div class="explain">
         Welcome! If you don't have a Git account, you can't do anything here.<br>
-        You can <a href="bug.php?id=<?php echo $bug_id; ?>&amp;edit=3">add a comment by following this link</a>
-        or if you reported this bug, you can <a href="bug.php?id=<?php echo $bug_id; ?>&amp;edit=2">edit this bug over here</a>.
+        If you reported this bug, you can <a href="bug.php?id=<?php echo $bug_id; ?>&amp;edit=2">edit this bug over here</a>.
         <div class="details">
             <label for="svnuser">php.net Username:</label>
             <input type="text" id="svnuser" name="user" value="<?php echo htmlspecialchars($user) ?>" size="10" maxlength="20">

--- a/www/patch-add.php
+++ b/www/patch-add.php
@@ -16,6 +16,13 @@ session_start();
 // Authenticate
 bugs_authenticate($user, $pw, $logged_in, $user_flags);
 
+if (!$logged_in) {
+    response_header('Developers only');
+    display_bug_error('Only developers are allowed to add patches');
+    response_footer();
+    exit;
+}
+
 $canpatch = true;
 
 /// Input vars

--- a/www/vote.php
+++ b/www/vote.php
@@ -3,6 +3,8 @@
 use App\Repository\BugRepository;
 use App\Repository\VoteRepository;
 
+die('Voting on tickets is disabled');
+
 // Obtain common includes
 require_once '../include/prepend.php';
 


### PR DESCRIPTION
All further conversation about bugs is supposed to happen on Github. We still allow developers to edit the bug tracker, so they can clean up.

We start by disallowing users to add patches.

TODO:
* [x] disallow commenting
* [ ] disallow adding PRs? (probably not)
* [x] disallow voting (it's broken anyway, see #112)
* [ ] disallow original reporters to edit/comment? (probably not)
* more?
---

Note that I do not have a development environment for web-bugs, so this is completely untested. Maybe somebody with a development environment can check this? (and perhaps even help to solve further tasks)