### PR TITLE
Updated report.php to remove PECL and PEAR issues

### DIFF
--- a/www/report.php
+++ b/www/report.php
@@ -10,8 +10,6 @@ response_header('Report - New');
     <ul>
         <li>Implementation issues: <a href="https://github.com/php/php-src/issues">php/php-src repository</a></li>
         <li>Documentation issues: <a href="https://github.com/php/doc-en/issues">php/doc-en repository</a></li>
-        <li>PECL extension issues: Find the correct extension-specific bug tracker at <a href="https://pecl.php.net/">pecl.php.net</a></li>
-        <li>PEAR issues: <a href="https://pear.php.net/bugs/">pear.php.net/bugs</a></li>
         <li>Security issues: <a href="https://github.com/php/php-src/security/advisories/new">php/php-src security advisory</a>, or email <?php echo make_mailto_link("{$site_data['security_email']}?subject=%5BSECURITY%5D+possible+new+bug%21", $site_data['security_email']); ?></li>
     </ul>
 </p>


### PR DESCRIPTION
Removed PECL and PEAR issues links. I ended up on this page coming from the deprecated PECL, sending back to PECL doesn't make sense. Likewise, it doesn't make sense to keep PEAR listed for known reasons.